### PR TITLE
Sitemap: decrease chunk size from 40k to 500 and removed nested sitem…

### DIFF
--- a/components/NodeHead.tsx
+++ b/components/NodeHead.tsx
@@ -9,9 +9,10 @@ type NodeHeadProps = {
   keywords: string;
   updatedStr: string;
   createdStr: string;
+  canonical?: string;
 };
 
-export const NodeHead = ({ node, keywords, updatedStr, createdStr }: NodeHeadProps) => {
+export const NodeHead = ({ node, keywords, updatedStr, createdStr, canonical }: NodeHeadProps) => {
   const {
     id,
     title,
@@ -103,7 +104,7 @@ export const NodeHead = ({ node, keywords, updatedStr, createdStr }: NodeHeadPro
 
   return (
     <Head>
-      <link rel="canonical" href={`${getNodePageWithDomain(title || "", id)}`} key="canonical" />
+      <link rel="canonical" href={canonical ? canonical : (`${getNodePageWithDomain(title || "", id)}`)} key="canonical" />
       <meta name="topic" content={`1Cademy - ${escapeBreaksQuotes(title)}`} />
       <meta name="subject" content={`1Cademy - ${escapeBreaksQuotes(title)}`} />
       <meta name="Classification" content={nodeType} />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -31,6 +31,10 @@ export const encodeTitle = (title?: string) => {
   return encodeURI(escapeBreaksQuotes(title)).replace(/[&\/\?\\]/g, "");
 };
 
+export function generateAlias(name?: string) {
+  return String(name).toLowerCase().replace(/[^a-z- ]/g, '').trim().replace(/ /g, '-')
+}
+
 export const getQueryParameter = (val: string | string[] | undefined) => {
   if (Array.isArray(val)) {
     return val[0];

--- a/pages/node/[title]/[id].tsx
+++ b/pages/node/[title]/[id].tsx
@@ -15,7 +15,7 @@ import PagesNavbar from "../../../components/PagesNavbar";
 import { ReferencesList } from "../../../components/ReferencesList";
 import { TagsList } from "../../../components/TagsList";
 import { getAllNodeParamsForStaticProps, getNodeData } from "../../../lib/nodes";
-import { escapeBreaksQuotes } from "../../../lib/utils";
+import { escapeBreaksQuotes, generateAlias } from "../../../lib/utils";
 import { KnowledgeNode } from "../../../src/knowledgeTypes";
 
 type Props = {
@@ -77,7 +77,7 @@ const NodePage: NextPage<Props> = ({ node, keywords, createdStr, updatedStr }) =
   return (
     <PagesNavbar title={`1Cademy - ${node.title}`} showSearch={false}>
       <Box data-testid="node-item-container" sx={{ p: { xs: 3, md: 10 } }}>
-        <NodeHead node={node} keywords={keywords} createdStr={createdStr} updatedStr={updatedStr} />
+        <NodeHead canonical={generateAlias(node.title)} node={node} keywords={keywords} createdStr={createdStr} updatedStr={updatedStr} />
         <Grid container spacing={3}>
           <Grid item xs={12} sm={12} md={3}>
             {parents && parents?.length > 0 && <LinkedNodes data={parents || []} header="Learn Before" />}


### PR DESCRIPTION
## Description

- Removed nested sitemaps
- Decreased chunk size from 40k to 500
- Added canonical meta in node page so, that we don't duplicate urls because of alias name changes

Ref #66 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
