### PR TITLE
Fix/auto focus and tab components

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,7 +1,7 @@
 import { Input, InputLabel, Switch, Typography } from "@mui/material";
 import { Box } from "@mui/system";
 import { SxProps, Theme } from "@mui/system";
-import React, { useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 
 import MarkdownRender from "./Markdown/MarkdownRender";
 
@@ -53,6 +53,21 @@ export const Editor = ({ label, value, setValue, readOnly, sxPreview, onBlurCall
     [label]
   );
 
+  const titleFocus = useCallback(
+    (inputTitle: HTMLElement) => {
+      if (inputTitle && label === "Please enter the node title below:") {
+        inputTitle.focus();
+      }
+    },
+    [label]
+  );
+
+  const moveToEnd = useCallback((e: any) => {
+    const tmpValue = e.target.value;
+    e.target.value = "";
+    e.target.value = tmpValue;
+  }, []);
+
   return (
     <Box className={readOnly ? "HyperEditor ReadOnlyEditor" : "HyperEditor"} sx={{ width: "100%" }}>
       {!readOnly && (
@@ -60,60 +75,43 @@ export const Editor = ({ label, value, setValue, readOnly, sxPreview, onBlurCall
           {label}
         </InputLabel>
       )}
-
-      {!readOnly && (
-        <Box sx={{ display: "flex", justifyContent: "end", alignItems: "center" }}>
-          <Typography onClick={() => setOption("PREVIEW")} sx={{ cursor: "pointer", fontSize: "14px" }}>
-            Preview
-          </Typography>
-          <Switch checked={option === "EDIT"} onClick={() => onChangeOption(option === "EDIT")} size="small" />
-          <Typography onClick={() => setOption("EDIT")} sx={{ cursor: "pointer", fontSize: "14px" }}>
-            Edit
-          </Typography>
-
-          {/* <Button
-            color={"secondary"}
-            variant={option === "EDIT" ? "contained" : "outlined"}
-            onClick={() => setOption("EDIT")}
-            size="small"
-            sx={{ py: "0px" }}
-          >
-            Edit
-          </Button>
-          <Button
-            color={"secondary"}
-            variant={option === "PREVIEW" ? "contained" : "outlined"}
-            onClick={() => setOption("PREVIEW")}
-            size="small"
-            sx={{ py: "0px" }}
-          >
-            Preview
-          </Button> */}
-        </Box>
-      )}
-
-      {/* {!readOnly && <hr />} */}
-      {/* sx={{ border: readOnly ? undefined : "solid 2px gray" }} */}
-      <Box>
-        {option === "EDIT" && !readOnly ? (
-          <Input
-            id={inputId}
-            ref={inputRef}
-            fullWidth
-            multiline
-            value={value}
-            onChange={e => setValue(e.target.value)}
-            onBlur={onBlurCallback ? e => onBlurCallback(e.target.value) : undefined}
-            // onBlur={onBlurCallback ? e => onBlurCallback(e.target.value) : undefined}
-            sx={{ p: "0px", m: "0px", fontWeight: 400, lineHeight: "24px" }}
-          />
-        ) : (
-          <Box>
-            <MarkdownRender
-              text={value}
-              customClass={"custom-react-markdown"}
-              sx={{ ...sxPreview, fontWeight: 400, letterSpacing: "inherit" }}
+      <Box sx={{ display: "flex", flexDirection: "column-reverse" }}>
+        <Box>
+          {option === "EDIT" && !readOnly ? (
+            <Input
+              id={inputId}
+              ref={inputRef}
+              fullWidth
+              multiline
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onBlur={onBlurCallback ? e => onBlurCallback(e.target.value) : undefined}
+              inputRef={titleFocus}
+              onFocus={moveToEnd}
+              sx={{ p: "0px", m: "0px", fontWeight: 400, lineHeight: "24px" }}
             />
+          ) : (
+            <Box>
+              <MarkdownRender
+                text={value}
+                customClass={"custom-react-markdown"}
+                sx={{ ...sxPreview, fontWeight: 400, letterSpacing: "inherit" }}
+              />
+            </Box>
+          )}
+        </Box>
+        {!readOnly && (
+          <Box sx={{ display: "flex", justifyContent: "end", alignItems: "center" }}>
+            <Typography
+              onClick={() => setOption("PREVIEW")}
+              sx={{ cursor: "pointer", fontSize: "14px", fontWeight: 490 }}
+            >
+              Preview
+            </Typography>
+            <Switch checked={option === "EDIT"} onClick={() => onChangeOption(option === "EDIT")} size="small" />
+            <Typography onClick={() => setOption("EDIT")} sx={{ cursor: "pointer", fontSize: "14px", fontWeight: 490 }}>
+              Edit
+            </Typography>
           </Box>
         )}
       </Box>


### PR DESCRIPTION
## Description
- I used input-ref prop then used a function to focus the input title at the end of the value.
- I changed order component in DOM then i used flex box column reverse to allow tab navigation in order.

Ref #110  

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
