### PR TITLE
For now sort options will be uncheck by default in node search section

### DIFF
--- a/src/components/map/Sidebar/SearchList.tsx
+++ b/src/components/map/Sidebar/SearchList.tsx
@@ -129,7 +129,7 @@ const SearchList = ({ openLinkedNode }: SearchListProps) => {
   const [onlyTags /*setOnlyTags*/] = useState(true);
   const [showTagSelector, setShowTagSelector] = useState(false);
   const [nodeTypes, setNodeTypes] = useState(NODE_TYPES_ARRAY);
-  const [sortOption, setSortOption] = useState<SortValues>("DATE_MODIFIED");
+  const [sortOption, setSortOption] = useState<SortValues>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>("DESCENDING");
   const [chosenTags, setChosenTags] = useState<ChosenTag[]>([]);
   const [search, setSearch] = useState<string>(nodeBookState.searchQuery);

--- a/src/components/map/Sidebar/SearchList.tsx
+++ b/src/components/map/Sidebar/SearchList.tsx
@@ -129,7 +129,7 @@ const SearchList = ({ openLinkedNode }: SearchListProps) => {
   const [onlyTags /*setOnlyTags*/] = useState(true);
   const [showTagSelector, setShowTagSelector] = useState(false);
   const [nodeTypes, setNodeTypes] = useState(NODE_TYPES_ARRAY);
-  const [sortOption, setSortOption] = useState<SortValues>(null);
+  const [sortOption, setSortOption] = useState<SortValues>("NOT_SELECTED");
   const [sortDirection, setSortDirection] = useState<SortDirection>("DESCENDING");
   const [chosenTags, setChosenTags] = useState<ChosenTag[]>([]);
   const [search, setSearch] = useState<string>(nodeBookState.searchQuery);

--- a/src/nodeBookTypes.ts
+++ b/src/nodeBookTypes.ts
@@ -255,7 +255,14 @@ export type FullNodesData = { [key: string]: FullNodeData };
 export type EdgesData = { [key: string]: EdgeData };
 
 export type SortDirection = "ASCENDING" | "DESCENDING";
-export type SortValues = "LAST_VIEWED" | "DATE_MODIFIED" | "PROPOSALS" | "UP_VOTES" | "DOWN_VOTES" | "NET_NOTES" | null;
+export type SortValues =
+  | "LAST_VIEWED"
+  | "DATE_MODIFIED"
+  | "PROPOSALS"
+  | "UP_VOTES"
+  | "DOWN_VOTES"
+  | "NET_NOTES"
+  | "NOT_SELECTED";
 export type UsersStatus = "All Time" | "Monthly" | "Weekly" | "Others Votes" | "Others Monthly";
 
 export type Cluster = {

--- a/src/nodeBookTypes.ts
+++ b/src/nodeBookTypes.ts
@@ -255,7 +255,7 @@ export type FullNodesData = { [key: string]: FullNodeData };
 export type EdgesData = { [key: string]: EdgeData };
 
 export type SortDirection = "ASCENDING" | "DESCENDING";
-export type SortValues = "LAST_VIEWED" | "DATE_MODIFIED" | "PROPOSALS" | "UP_VOTES" | "DOWN_VOTES" | "NET_NOTES";
+export type SortValues = "LAST_VIEWED" | "DATE_MODIFIED" | "PROPOSALS" | "UP_VOTES" | "DOWN_VOTES" | "NET_NOTES" | null;
 export type UsersStatus = "All Time" | "Monthly" | "Weekly" | "Others Votes" | "Others Monthly";
 
 export type Cluster = {


### PR DESCRIPTION
## Description

For now, sort options will be unchecked by default in the node search section

Ref #204 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
