### PR TITLE
Improved node type icon sizes and added margin in title of nodes

### DIFF
--- a/src/components/map/LinkingWords/LinkingButton.tsx
+++ b/src/components/map/LinkingWords/LinkingButton.tsx
@@ -47,14 +47,14 @@ const LinkingButton = (props: LinkingButtonProps) => {
           : "left"
       }
     >
-      <Box sx={{ display: "flex", alignItems: "center" }}>
+      <Box sx={{ display: "flex", alignItems: "center", fontSize: "16px" }}>
         <NodeTypeIcon
           nodeType={props.nodeType}
           tooltipPlacement={"left"}
+          fontSize={"inherit"}
           sx={{
-            fontSize: "16px",
+            marginRight: "4px",
             color: props.linkedNodeType !== "children" ? (props.visible ? "#00E676" : "#f9a825") : "gray",
-            pr: "4px",
           }}
         />
         <Editor
@@ -62,7 +62,7 @@ const LinkingButton = (props: LinkingButtonProps) => {
           setValue={doNothing}
           label={""}
           value={props.linkedNodeTitle}
-          sxPreview={{ fontSize: "14px" }}
+          sxPreview={{ fontSize: "14px", lineHeight: "1.5" }}
         />
         {/* CHECK: I commented this, please uncomment this */}
         {/* <HyperEditor readOnly={true} onChange={doNothing} content={props.linkedNodeTitle} /> */}

--- a/src/components/map/LinkingWords/LinkingWords.tsx
+++ b/src/components/map/LinkingWords/LinkingWords.tsx
@@ -169,7 +169,12 @@ const LinkingWords = (props: LinkingWordsProps) => {
             <strong>Parents (Prerequisites)</strong>
             {props.parents.map((parent: any, idx: number) => {
               return (
-                <div key={props.identifier + "LinkTo" + parent.node}>
+                <div
+                  style={{
+                    margin: "5px 5px 0px 5px",
+                  }}
+                  key={props.identifier + "LinkTo" + parent.node}
+                >
                   <LinkingButton
                     onClick={props.openLinkedNode}
                     // nodeID={props.identifier}
@@ -212,7 +217,13 @@ const LinkingWords = (props: LinkingWordsProps) => {
                 }
               }
               return (
-                <div key={props.identifier + "LinkTo" + reference.node + "DIV"} className="ReferenceLink">
+                <div
+                  style={{
+                    margin: "5px 5px 0px 5px",
+                  }}
+                  key={props.identifier + "LinkTo" + reference.node + "DIV"}
+                  className="ReferenceLink"
+                >
                   <LinkingButton
                     key={props.identifier + "LinkTo" + reference.node}
                     onClick={props.openLinkedNode}
@@ -320,7 +331,12 @@ const LinkingWords = (props: LinkingWordsProps) => {
             <strong>Tags</strong>
             {props.tags.map((tag: any, idx: number) => {
               return (
-                <div key={props.identifier + "LinkTo" + tag.node + "DIV"}>
+                <div
+                  style={{
+                    margin: "5px 5px 0px 5px",
+                  }}
+                  key={props.identifier + "LinkTo" + tag.node + "DIV"}
+                >
                   <LinkingButton
                     key={props.identifier + "LinkTo" + tag.node}
                     onClick={props.openLinkedNode}
@@ -363,7 +379,12 @@ const LinkingWords = (props: LinkingWordsProps) => {
             <strong>Children (Follow-ups)</strong>
             {props.nodesChildren.map((child: any, idx: number) => {
               return (
-                <div key={props.identifier + "LinkTo" + child.node + "DIV"}>
+                <div
+                  style={{
+                    margin: "5px 5px 0px 5px",
+                  }}
+                  key={props.identifier + "LinkTo" + child.node + "DIV"}
+                >
                   <LinkingButton
                     key={props.identifier + "LinkTo" + child.node}
                     onClick={props.openLinkedNode}


### PR DESCRIPTION
## Description

I have improved node-type icon sizes and added a margin in the title of nodes.

Ref #215 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
