### PR TITLE
Task/get rid of border around choices

### DIFF
--- a/src/components/map/QuestionChoices.tsx
+++ b/src/components/map/QuestionChoices.tsx
@@ -154,7 +154,10 @@ const QuestionChoices = (props: QuestionChoicesProps) => {
           <Editor label="" readOnly={true} value={props.choice.choice} setValue={doNothing} />
         </div>
         {choicesOpen[props.idx] && (
-          <div className="collapsible-body" style={{ display: "block", border: "solid 1px white", padding: "5px" }}>
+          <div
+            className="collapsible-body"
+            style={{ display: "block", borderBottom: "solid 1px #fff", paddingLeft: "32px" }}
+          >
             <Editor label="" readOnly={true} value={props.choice.feedback} setValue={doNothing} />
           </div>
         )}

--- a/src/components/map/QuestionChoices.tsx
+++ b/src/components/map/QuestionChoices.tsx
@@ -140,21 +140,21 @@ const QuestionChoices = (props: QuestionChoicesProps) => {
         <div
           className="collapsible-header"
           onClick={choiceClick}
-          style={{ display: "flex", cursor: "pointer", border: "solid 1px white" }}
+          style={{ display: "flex", cursor: "pointer", alignItems: "center" }}
         >
           {choicesOpen[props.idx] ? (
             props.choice.correct ? (
-              <DoneIcon className="green-text" />
+              <DoneIcon className="green-text" sx={{ marginRight: "8px" }} />
             ) : (
-              <CloseIcon className="red-text" />
+              <CloseIcon className="red-text" sx={{ marginRight: "8px" }} />
             )
           ) : (
-            <CheckBoxOutlineBlankIcon />
+            <CheckBoxOutlineBlankIcon sx={{ marginRight: "8px" }} />
           )}
           <Editor label="" readOnly={true} value={props.choice.choice} setValue={doNothing} />
         </div>
         {choicesOpen[props.idx] && (
-          <div className="collapsible-body" style={{ display: "block", border: "solid 1px white" }}>
+          <div className="collapsible-body" style={{ display: "block", border: "solid 1px white", padding: "5px" }}>
             <Editor label="" readOnly={true} value={props.choice.feedback} setValue={doNothing} />
           </div>
         )}


### PR DESCRIPTION
## Description

- Removed borders from choices
- Aligned the checkboxes with the content
- Removed borders except left from choice feedback
- Added padding left to choice feedback

Ref #240 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
