### PR TITLE
change the CommunityLeaderboard trophy text to be below when we are in the mobile view

### DIFF
--- a/src/components/map/CommunityLeaderboard/CommunityLeaderboard.tsx
+++ b/src/components/map/CommunityLeaderboard/CommunityLeaderboard.tsx
@@ -203,17 +203,18 @@ const CommunityLeaderboard = ({ userTagId, pendingProposalsLoaded }: CommunityLe
   );
 
   return (
-    <div
+    <Box
       id="ComLeaderboardMain"
       className={comLeaderboardOpen ? undefined : "Minimized"}
+      sx={{ width: { xs: "70%", md: "90%" } }}
       // style={{ border: "solid 2px red" }}
     >
       {/* <div id="ComLeaderboardSidebarOverlap"></div> */}
-      <div id="ComLeaderboardMinimizer">
+      <Box id="ComLeaderboardMinimizer">
         <MemoizedMetaButton onClick={openComLeaderboard}>
           <Box sx={{ paddingRight: "5px" }}>{comLeaderboardOpen ? <ArrowForwardIcon /> : <ArrowBackIcon />}</Box>
         </MemoizedMetaButton>
-      </div>
+      </Box>
       <div
         id="ComLeaderboardContainer"
         className={
@@ -229,7 +230,16 @@ const CommunityLeaderboard = ({ userTagId, pendingProposalsLoaded }: CommunityLe
       >
         <div id="ComLeaderbaordChanger">
           <MemoizedMetaButton onClick={openComLeaderboardTypes}>
-            <Box sx={{ display: "flex", gap: "10px", alignItems: "center", paddingY: "5px", paddingLeft: "5px" }}>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: { xs: "column", md: "row" },
+                gap: { xs: "0px", md: "0px", lg: "10px", xl: "10px" },
+                alignItems: "center",
+                paddingY: "5px",
+                paddingLeft: "5px",
+              }}
+            >
               <div id="ComLeaderbaordChangerIcon">🏆</div>
               <div id="ComLeaderbaordChangerText">{comLeaderboardType}</div>
             </Box>
@@ -272,7 +282,7 @@ const CommunityLeaderboard = ({ userTagId, pendingProposalsLoaded }: CommunityLe
           )}
         </Box>
       </div>
-    </div>
+    </Box>
   );
 };
 

--- a/src/styles/ComLeaderboard.css
+++ b/src/styles/ComLeaderboard.css
@@ -6,7 +6,6 @@
   right: 0px;
   bottom: 0px;
   height: 85px;
-  width: 90%;
   z-index: 1;
   transition: width 1s ease-in-out; /* vendorless fallback */
   -o-transition: width 1s; /* opera */
@@ -44,7 +43,7 @@
   left: 0;
   top: 0;
   width: 40px;
-  height: 85px;
+  height: 90px;
   padding-right: 10px;
   border-radius: 10px 0px 0px 10px;
   background-color: rgb(31, 31, 31);
@@ -69,7 +68,7 @@
 #ComLeaderbaordChangerText {
   color: #dcdcdc;
   font-size: 16px;
-  width: 100px;
+  width: 63px;
   text-align: center;
   font-weight: bold;
   /* margin-bottom: 4px; */


### PR DESCRIPTION


## Description

Please include a summary of the change and which issue is fixed.
<img width="608" alt="image" src="https://user-images.githubusercontent.com/62210295/196977397-f36ce886-8bd4-4652-ace1-fbe8fa03b4d7.png">

Ref # (issue)

## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [ ] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
