### PR TITLE
Fix/improve call to scroll to node function

### DIFF
--- a/src/components/OptimizedAvatar.tsx
+++ b/src/components/OptimizedAvatar.tsx
@@ -1,8 +1,7 @@
 import { Avatar, Box } from "@mui/material";
 import { SxProps, Theme } from "@mui/system";
-import { getDownloadURL, getStorage, ref } from "firebase/storage";
 import Image from "next/image";
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useState } from "react";
 type Props = {
   name?: string;
   imageUrl?: string;
@@ -12,29 +11,29 @@ type Props = {
 };
 
 const OptimizedAvatar: FC<Props> = ({ name = "", imageUrl, renderAsAvatar = true, contained = false, sx }) => {
-  const [checkIfFileExist, setCheckIfFileExist] = useState(false);
-  useEffect(() => {
-    if (imageUrl) {
-      const checkIfImageExists = async () => {
-        const storage = getStorage();
-        const storageRef = ref(storage, imageUrl);
+  const [checkIfFileExist /*setCheckIfFileExist*/] = useState(false);
+  // useEffect(() => {
+  //   if (imageUrl) {
+  //     const checkIfImageExists = async () => {
+  //       const storage = getStorage();
+  //       const storageRef = ref(storage, imageUrl);
 
-        getDownloadURL(storageRef)
-          .then(() => {
-            setCheckIfFileExist(true);
-          })
-          .catch(error => {
-            if (error.code === "storage/object-not-found") {
-              setCheckIfFileExist(false);
-            } else {
-              return Promise.reject(error);
-            }
-          });
-      };
+  //       getDownloadURL(storageRef)
+  //         .then(() => {
+  //           setCheckIfFileExist(true);
+  //         })
+  //         .catch(error => {
+  //           if (error.code === "storage/object-not-found") {
+  //             setCheckIfFileExist(false);
+  //           } else {
+  //             return Promise.reject(error);
+  //           }
+  //         });
+  //     };
 
-      checkIfImageExists();
-    }
-  }, [imageUrl]);
+  //     checkIfImageExists();
+  //   }
+  // }, [imageUrl]);
 
   const getInstitutions = (instName: string, index: number): string => {
     if (!instName?.split(" ")[index]) return "";

--- a/src/components/map/LinkingWords/LinkingWords.tsx
+++ b/src/components/map/LinkingWords/LinkingWords.tsx
@@ -162,11 +162,11 @@ const LinkingWords = (props: LinkingWordsProps) => {
   );
 
   const onCancelProposal = () => {
-    props.closeSideBar();
     const firstParentId = props.parents[0];
     if (!firstParentId) return;
-
-    nodeBookDispatch({ type: "setSelectedNode", payload: firstParentId.node });
+    const scrollTo = props.isNew ? firstParentId.node : props.identifier;
+    nodeBookDispatch({ type: "setSelectedNode", payload: scrollTo });
+    props.closeSideBar();
   };
 
   return props.openPart === "LinkingWords" || props.openPart === "Tags" || props.openPart === "References" ? (

--- a/src/components/map/LinkingWords/LinkingWords.tsx
+++ b/src/components/map/LinkingWords/LinkingWords.tsx
@@ -143,23 +143,31 @@ const LinkingWords = (props: LinkingWordsProps) => {
   );
 
   const proposalSubmit = useCallback(
-    () =>
-      props.isNew
-        ? props.saveProposedChildNode(
-            props.identifier,
-            // summary,
-            "",
-            props.reason
-          )
-        : props.saveProposedImprovement(
-            // summary,
-            "",
-            props.reason
-          ),
+    () => {
+      const firstParentId = props.parents[0];
+
+      if (props.isNew) {
+        props.saveProposedChildNode(props.identifier, "", props.reason);
+        if (!firstParentId) return;
+        nodeBookDispatch({ type: "setSelectedNode", payload: firstParentId.node });
+        return;
+      }
+      props.saveProposedImprovement("", props.reason);
+      nodeBookDispatch({ type: "setSelectedNode", payload: props.identifier });
+    },
+
     // TODO: check dependencies to remove eslint-disable-next-line
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.isNew, props.identifier, props.reason, props.saveProposedChildNode, props.saveProposedImprovement]
   );
+
+  const onCancelProposal = () => {
+    props.closeSideBar();
+    const firstParentId = props.parents[0];
+    if (!firstParentId) return;
+
+    nodeBookDispatch({ type: "setSelectedNode", payload: firstParentId.node });
+  };
 
   return props.openPart === "LinkingWords" || props.openPart === "Tags" || props.openPart === "References" ? (
     <div className="LinkingWordsContainer card-action">
@@ -308,7 +316,7 @@ const LinkingWords = (props: LinkingWordsProps) => {
                 color="error"
                 variant="contained"
                 className="btn waves-effect waves-light hoverable red"
-                onClick={props.closeSideBar}
+                onClick={onCancelProposal}
               >
                 Cancel
               </Button>

--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -215,7 +215,7 @@ const Node = ({
       try {
         const { blockSize } = entries[0].borderBoxSize[0];
         const topPosition = (entries[0].target as any)?.style?.top;
-        const isSimilar = blockSize === previousHeightRef.current && topPosition === previousTopRef.current;
+        const isSimilar = blockSize === previousHeightRef.current; /* && topPosition === previousTopRef.current */
         previousHeightRef.current = blockSize;
         previousTopRef.current = topPosition;
         if (isSimilar) return;

--- a/src/hooks/useWorkerQueue.tsx
+++ b/src/hooks/useWorkerQueue.tsx
@@ -33,6 +33,7 @@ type UseWorkerQueueProps = {
   mapWidth: number;
   mapHeight: number;
   allTags: AllTagsTreeView;
+  onComplete: () => void;
 };
 export const useWorkerQueue = ({
   g,
@@ -45,6 +46,7 @@ export const useWorkerQueue = ({
   mapWidth,
   mapHeight,
   allTags,
+  onComplete,
 }: UseWorkerQueueProps) => {
   const [tasksToWait, setTasksToWait] = useState<number>(0);
   const [queue, setQueue] = useState<Task[]>([]);
@@ -145,23 +147,15 @@ export const useWorkerQueue = ({
         });
         // setMapChanged(mapChangedFlag); // CHECK: if is used
         setIsWorking(false);
+        onComplete();
       };
     },
-    [
-      allTags,
-      g,
-      mapHeight,
-      mapWidth,
-      // setClusterNodes,
-      setGraph,
-      setMapHeight,
-      setMapWidth,
-    ]
+    [allTags, g, mapHeight, mapWidth, onComplete, setGraph, setMapHeight, setMapWidth]
   );
 
   useEffect(() => {
-    console.log("[queue]: useEffect", { graph, tasksToWait, queueL: queue.length });
-    if (!didWork && tasksToWait >= queue.length) return; // if us first load, need to wait until get required tasks
+    console.log("[queue]: useEffect");
+    if (!didWork && tasksToWait > queue.length) return; // if us first load, need to wait until get required tasks
     if (isQueueWorking) return;
     if (!queue.length) return;
     if (!g?.current) return;

--- a/src/hooks/useWorkerQueue.tsx
+++ b/src/hooks/useWorkerQueue.tsx
@@ -147,7 +147,9 @@ export const useWorkerQueue = ({
         });
         // setMapChanged(mapChangedFlag); // CHECK: if is used
         setIsWorking(false);
-        onComplete();
+        setTimeout(() => {
+          onComplete();
+        }, 1000);
       };
     },
     [allTags, g, mapHeight, mapWidth, onComplete, setGraph, setMapHeight, setMapWidth]

--- a/src/hooks/useWorkerQueue.tsx
+++ b/src/hooks/useWorkerQueue.tsx
@@ -46,6 +46,7 @@ export const useWorkerQueue = ({
   mapHeight,
   allTags,
 }: UseWorkerQueueProps) => {
+  const [tasksToWait, setTasksToWait] = useState<number>(0);
   const [queue, setQueue] = useState<Task[]>([]);
   const [isQueueWorking, setIsWorking] = useState(false);
   const [didWork, setDidWork] = useState(false);
@@ -105,7 +106,7 @@ export const useWorkerQueue = ({
         const gg = dagreUtils.mapObjectToGraph(gObject);
 
         worker.terminate();
-        // console.log("[queue]: ", { g: g.current, gg });
+        console.log("[queue]:FINISH ", { g: g.current, gg });
         g.current = gg;
         setMapWidth(oldMapWidth);
         setMapHeight(oldMapHeight);
@@ -158,7 +159,8 @@ export const useWorkerQueue = ({
   );
 
   useEffect(() => {
-    // console.log("[queue]: useEffect", { graph });
+    console.log("[queue]: useEffect", { graph, tasksToWait, queueL: queue.length });
+    if (tasksToWait >= queue.length) return; // if we donat have required amount of task, we will wait
     if (isQueueWorking) return;
     if (!queue.length) return;
     if (!g?.current) return;
@@ -175,7 +177,7 @@ export const useWorkerQueue = ({
 
     recalculateGraphWithWorker(nodesToRecalculate, graph.edges);
     setQueue([]);
-  }, [allTags, g, graph, isQueueWorking, queue, recalculateGraphWithWorker]);
+  }, [allTags, g, graph, isQueueWorking, queue, recalculateGraphWithWorker, tasksToWait]);
 
   const addTask = (newTask: Task) => {
     // console.log("addTask", newTask);
@@ -190,5 +192,5 @@ export const useWorkerQueue = ({
     return true;
   }, [didWork, isQueueWorking, queue.length]);
 
-  return { addTask, queue, isQueueWorking, queueFinished };
+  return { addTask, queue, isQueueWorking, queueFinished, setTasksToWait };
 };

--- a/src/hooks/useWorkerQueue.tsx
+++ b/src/hooks/useWorkerQueue.tsx
@@ -63,6 +63,7 @@ export const useWorkerQueue = ({
       setIsWorking(true);
       const worker: Worker = new Worker(new URL("../workers/MapWorker.ts", import.meta.url));
 
+      console.log("[queue]: ---------------> START ");
       worker.postMessage({
         // mapChangedFlag,
         // oldClusterNodes,
@@ -106,7 +107,7 @@ export const useWorkerQueue = ({
         const gg = dagreUtils.mapObjectToGraph(gObject);
 
         worker.terminate();
-        console.log("[queue]:FINISH ", { g: g.current, gg });
+        console.log("[queue]: ---------------> FINISH ", { g: g.current, gg });
         g.current = gg;
         setMapWidth(oldMapWidth);
         setMapHeight(oldMapHeight);
@@ -160,7 +161,7 @@ export const useWorkerQueue = ({
 
   useEffect(() => {
     console.log("[queue]: useEffect", { graph, tasksToWait, queueL: queue.length });
-    if (tasksToWait >= queue.length) return; // if we donat have required amount of task, we will wait
+    if (!didWork && tasksToWait >= queue.length) return; // if us first load, need to wait until get required tasks
     if (isQueueWorking) return;
     if (!queue.length) return;
     if (!g?.current) return;
@@ -177,7 +178,7 @@ export const useWorkerQueue = ({
 
     recalculateGraphWithWorker(nodesToRecalculate, graph.edges);
     setQueue([]);
-  }, [allTags, g, graph, isQueueWorking, queue, recalculateGraphWithWorker, tasksToWait]);
+  }, [allTags, didWork, g, graph, isQueueWorking, queue, recalculateGraphWithWorker, tasksToWait]);
 
   const addTask = (newTask: Task) => {
     // console.log("addTask", newTask);

--- a/src/lib/utils/develop.util.ts
+++ b/src/lib/utils/develop.util.ts
@@ -5,10 +5,9 @@
  * - logInUpperCase must be writer to sho log like this: FUNCTION_NAME
  */
 const disableLogsTemporally = false;
-export const devLog = (logInUpperCase: string, otherData: any = null) => {
+export const devLog = (logInUpperCase: string, otherData = {}) => {
   if (disableLogsTemporally) return;
   if (process.env.NODE_ENV !== "development") return;
 
-  const subLog = otherData ? `:${otherData}` : "";
-  console.log(`[${logInUpperCase.toUpperCase()}]${subLog}`);
+  console.log(`[${logInUpperCase.toUpperCase()}]`, otherData);
 };

--- a/src/lib/utils/develop.util.ts
+++ b/src/lib/utils/develop.util.ts
@@ -4,7 +4,7 @@
  * - this will print [FUNCTION_NAME]
  * - logInUpperCase must be writer to sho log like this: FUNCTION_NAME
  */
-const disableLogsTemporally = true;
+const disableLogsTemporally = false;
 export const devLog = (logInUpperCase: string, otherData: any = null) => {
   if (disableLogsTemporally) return;
   if (process.env.NODE_ENV !== "development") return;

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -2764,10 +2764,12 @@ const Dashboard = ({}: DashboardProps) => {
         // });
         // console.log(4, { newNodes, newEdges });
         // setMapChanged(true);
-        setTimeout(() => {
-          console.log("call scroll", newNodeId);
-          scrollToNode(newNodeId);
-        }, 10000);
+        // setTimeout(() => {
+        //   console.log("call scroll", newNodeId);
+        //   scrollToNode(newNodeId);
+        // }, 10000);
+        nodeBookDispatch({ type: "setSelectedNode", payload: newNodeId });
+        lastOperation.current = "OpenNode";
         return { nodes: newNodes, edges: newEdges };
       });
     },

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -197,7 +197,6 @@ const Dashboard = ({}: DashboardProps) => {
   const g = useRef(dagreUtils.createGraph());
 
   const scrollToNode = useCallback((nodeId: string, tries = 0) => {
-    // console.log("scrollToNodeInitialized", { scrollToNodeInitialized, tries });
     devLog("scroll To Node", { nodeId, tries });
     if (tries === 10) return;
 
@@ -241,7 +240,6 @@ const Dashboard = ({}: DashboardProps) => {
   }, []);
 
   const onCompleteWorker = useCallback(() => {
-    console.log("onCompleteWorker", nodeBookState.selectedNode);
     if (!nodeBookState.selectedNode) return;
 
     scrollToNode(nodeBookState.selectedNode);
@@ -529,7 +527,7 @@ const Dashboard = ({}: DashboardProps) => {
         async snapshot => {
           const docChanges = snapshot.docChanges();
 
-          console.log("first:docChanges", { docChanges, pW: snapshot.metadata.hasPendingWrites });
+          // console.log("first:docChanges", { docChanges, pW: snapshot.metadata.hasPendingWrites });
           if (!docChanges.length) return null;
           // setIsSubmitting(true);
           const userNodeChanges = getUserNodeChanges(docChanges);
@@ -590,7 +588,6 @@ const Dashboard = ({}: DashboardProps) => {
             // })
             // here we are filling dagger
             const { newNodes, newEdges } = fillDagre(visibleFullNodesMerged, nodes, edges);
-            console.log("visibleFullNodesMerged", visibleFullNodesMerged.length);
             setTasksToWait(visibleFullNodesMerged.length);
             return { nodes: newNodes, edges: newEdges };
           });
@@ -608,13 +605,12 @@ const Dashboard = ({}: DashboardProps) => {
           });
           setUserNodesLoaded(true);
         },
-        error => console.error(error),
-        () => console.log("snapsho is COMPLETE")
+        error => console.error(error)
       );
 
       return () => userNodesSnapshot();
     },
-    [allTags, db]
+    [allTags, db, setTasksToWait]
   );
 
   useEffect(
@@ -1608,16 +1604,9 @@ const Dashboard = ({}: DashboardProps) => {
 
           // const id = userNodeLogRef.id
           batch.set(doc(userNodeLogRef), userNodeLogData);
-
           await batch.commit();
-          //  there are some places when calling scroll to node but we are not selecting that node
-          console.log("will call openNode handler");
-          nodeBookDispatch({ type: "setSelectedNode", payload: nodeId });
 
-          // setTimeout(() => {
-          //   // scrollToNode(nodeId);
-          //   // setSelectedNode(nodeId);
-          // }, 0);
+          nodeBookDispatch({ type: "setSelectedNode", payload: nodeId });
         } catch (err) {
           console.error(err);
         }
@@ -1633,13 +1622,8 @@ const Dashboard = ({}: DashboardProps) => {
       if (!nodeBookState.choosingNode) {
         let linkedNode = document.getElementById(linkedNodeID);
         if (linkedNode) {
-          console.log("link node exist");
           nodeBookDispatch({ type: "setSelectedNode", payload: linkedNodeID });
           scrollToNode(linkedNodeID);
-
-          // setTimeout(() => {
-          //   // setSelectedNode(linkedNodeID);
-          // }, 400);
         } else {
           openNodeHandler(linkedNodeID);
         }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1236,6 +1236,7 @@ const Dashboard = ({}: DashboardProps) => {
         // setTimeout(() => {
         //   scrollToNode(nodeId);
         // }, 1500);
+        scrollToNode(nodeId);
         oldNodes[nodeId] = thisNode;
         return { nodes: oldNodes, edges: newEdges };
       });

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -195,7 +195,7 @@ const Dashboard = ({}: DashboardProps) => {
   const previousLengthNodes = useRef(0);
   const g = useRef(dagreUtils.createGraph());
 
-  const { addTask, queue, isQueueWorking, queueFinished } = useWorkerQueue({
+  const { addTask, queue, isQueueWorking, queueFinished, setTasksToWait } = useWorkerQueue({
     g,
     graph,
     setGraph,
@@ -492,24 +492,6 @@ const Dashboard = ({}: DashboardProps) => {
         );
       };
 
-      // const mergeAllNodes = (newAllNodes: FullNodeData[], currentAllNodes: FullNodeData[]) => {
-      //   return newAllNodes.reduce(
-      //     (acu, cur) => {
-      //       if (cur.nodeChangeType === "added") {
-      //         return [...acu, cur];
-      //       }
-      //       if (cur.nodeChangeType === "modified") {
-      //         return acu.map(c => (c.userNodeId === cur.userNodeId ? cur : c));
-      //       }
-      //       if (cur.nodeChangeType === "removed") {
-      //         return acu.filter(c => c.userNodeId !== cur.userNodeId);
-      //       }
-      //       return acu;
-      //     },
-      //     [...currentAllNodes]
-      //   );
-      // };
-
       const mergeAllNodes = (newAllNodes: FullNodeData[], currentAllNodes: FullNodesData): FullNodesData => {
         return newAllNodes.reduce(
           (acu, cur) => {
@@ -535,6 +517,7 @@ const Dashboard = ({}: DashboardProps) => {
 
       const userNodesSnapshot = onSnapshot(q, async snapshot => {
         const docChanges = snapshot.docChanges();
+        console.log("first:docChanges", { docChanges });
         if (!docChanges.length) return null;
         // setIsSubmitting(true);
         const userNodeChanges = getUserNodeChanges(docChanges);
@@ -595,7 +578,8 @@ const Dashboard = ({}: DashboardProps) => {
           // })
           // here we are filling dagger
           const { newNodes, newEdges } = fillDagre(visibleFullNodesMerged, nodes, edges);
-
+          console.log("visibleFullNodesMerged", visibleFullNodesMerged.length);
+          setTasksToWait(visibleFullNodesMerged.length);
           return { nodes: newNodes, edges: newEdges };
         });
         // setEdges(edges => {

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -2715,7 +2715,7 @@ const Dashboard = ({}: DashboardProps) => {
           editable: true,
           width: NODE_WIDTH,
           node: newNodeId,
-          left: thisNode.left,
+          left: thisNode.left + NODE_WIDTH + COLUMN_GAP,
           top: thisNode.top,
         };
         if (childNodeType === "Question") {
@@ -2743,7 +2743,7 @@ const Dashboard = ({}: DashboardProps) => {
         setTimeout(() => {
           console.log("call scroll", newNodeId);
           scrollToNode(newNodeId);
-        }, 1500);
+        }, 10000);
         return { nodes: newNodes, edges: newEdges };
       });
     },

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1236,7 +1236,6 @@ const Dashboard = ({}: DashboardProps) => {
         // setTimeout(() => {
         //   scrollToNode(nodeId);
         // }, 1500);
-
         oldNodes[nodeId] = thisNode;
         return { nodes: oldNodes, edges: newEdges };
       });


### PR DESCRIPTION
## Description

- we rid off `setTimeout` in every call of `scroll to node `
- we added a scroll to node `callback` to `useQueueWorker` which will run after worker ends

Ref #279 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
