### PR TITLE
disable the loader image in the first load temporarily

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -274,7 +274,7 @@ const Dashboard = ({}: DashboardProps) => {
   const [userNodesLoaded, setUserNodesLoaded] = useState(false);
 
   // flag set to true when sending request to server
-  const [isSubmitting, setIsSubmitting] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // flag to open proposal sidebar
   // const [openProposals, setOpenProposals] = useState(false);


### PR DESCRIPTION
## Description






https://user-images.githubusercontent.com/62210295/198356056-381bcb5e-acc4-4969-b1ef-9b6c0c752f48.mov



Ref #337 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
