### PR TITLE
Now when sidebar will close the node will remain selected

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -2719,7 +2719,7 @@ const Dashboard = ({}: DashboardProps) => {
         if (nodeBookState.selectedNode === nodeId && nodeBookState.selectionType === chosenType) {
           // setSelectedNode(null);
           // setSelectionType(null);
-          nodeBookDispatch({ type: "setSelectedNode", payload: null });
+          // nodeBookDispatch({ type: "setSelectedNode", payload: null });
           nodeBookDispatch({ type: "setSelectionType", payload: null });
           setSelectedNodeType(null);
           setOpenPendingProposals(false);


### PR DESCRIPTION
## Description

- Fixed node unselected issue when sidebar close

Ref #407 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
