### PR TITLE
Fix/scroll to node edit node

### DIFF
--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -119,6 +119,7 @@ type NodeProps = {
   setOpenSideBar: (sidebar: OpenSidebar) => void;
   proposeNodeImprovement: any;
   proposeNewChild: any;
+  scrollToNode: any;
 };
 
 const proposedChildTypesIcons: { [key in ProposedChildTypesIcons]: string } = {
@@ -208,6 +209,7 @@ const Node = ({
   proposeNodeImprovement,
   proposeNewChild,
   cleanEditorLink,
+  scrollToNode,
 }: NodeProps) => {
   // const choosingNode = useRecoilValue(choosingNodeState);
   // const choosingType = useRecoilValue(choosingTypeState);
@@ -280,12 +282,16 @@ const Node = ({
         nodeBookDispatch({ type: "setChosenNode", payload: { id: identifier, title } });
         // setChosenNode(identifier);
         // setChosenNodeTitle(title);
+        scrollToNode(nodeBookState.selectedNode);
       } else if (
         "activeElement" in event.currentTarget &&
         "nodeName" in event.currentTarget.activeElement &&
         event.currentTarget.activeElement.nodeName !== "INPUT"
       ) {
         nodeClicked(event, identifier, nodeType, setOpenPart);
+      }
+      if (event.target.type === "textarea") {
+        nodeBookDispatch({ type: "setSelectedNode", payload: identifier });
       }
     },
     [nodeBookState.choosingNode, identifier, title, nodeClicked, nodeType]

--- a/src/components/map/NodesList.tsx
+++ b/src/components/map/NodesList.tsx
@@ -48,6 +48,7 @@ type NodeListProps = {
   setOpenSideBar: (sidebar: OpenSidebar) => void;
   proposeNodeImprovement: any;
   proposeNewChild: any;
+  scrollToNode: any;
 };
 
 const NodesList = ({
@@ -88,6 +89,7 @@ const NodesList = ({
   setOpenSideBar,
   proposeNodeImprovement,
   proposeNewChild,
+  scrollToNode,
 }: NodeListProps) => {
   const { nodeBookState } = useNodeBook();
 
@@ -215,6 +217,7 @@ const NodesList = ({
             setOpenSideBar={setOpenSideBar}
             proposeNodeImprovement={proposeNodeImprovement}
             proposeNewChild={proposeNewChild}
+            scrollToNode={scrollToNode}
           />
         );
       })}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -268,7 +268,7 @@ const Dashboard = ({}: DashboardProps) => {
 
   const onCompleteWorker = useCallback(() => {
     if (!nodeBookState.selectedNode) return;
-
+    if (tempNodes.has(nodeBookState.selectedNode) || nodeBookState.selectedNode in changedNodes) return;
     scrollToNode(nodeBookState.selectedNode);
   }, [nodeBookState.selectedNode, scrollToNode]);
 
@@ -2887,12 +2887,13 @@ const Dashboard = ({}: DashboardProps) => {
         if (!nodeBookState.selectedNode) return { nodes: oldNodes, edges }; // CHECK: I added this to validate
 
         if (!(nodeBookState.selectedNode in changedNodes)) {
+          console.log("COPY : ", oldNodes[nodeBookState.selectedNode]);
           changedNodes[nodeBookState.selectedNode] = copyNode(oldNodes[nodeBookState.selectedNode]);
         }
         if (!tempNodes.has(newNodeId)) {
           tempNodes.add(newNodeId);
         }
-
+        console.log("COPY 2: ", oldNodes[nodeBookState.selectedNode]);
         const thisNode = copyNode(oldNodes[nodeBookState.selectedNode]);
 
         const newChildNode: any = {
@@ -2943,7 +2944,7 @@ const Dashboard = ({}: DashboardProps) => {
             },
           ];
         }
-
+        console.log("newChildNode", newChildNode);
         // console.log(2, { newNodeId, newChildNode });
         // let newEdges = edges;
 
@@ -2961,7 +2962,9 @@ const Dashboard = ({}: DashboardProps) => {
         //   scrollToNode(newNodeId);
         // }, 10000);
         nodeBookDispatch({ type: "setSelectedNode", payload: newNodeId });
-
+        setTimeout(() => {
+          scrollToNode(newNodeId);
+        }, 3500);
         return { nodes: newNodes, edges: newEdges };
       });
     },
@@ -3965,6 +3968,7 @@ const Dashboard = ({}: DashboardProps) => {
                   setOpenSideBar={setOpenSidebar}
                   proposeNodeImprovement={proposeNodeImprovement}
                   proposeNewChild={proposeNewChild}
+                  scrollToNode={scrollToNode}
                 />
               </MapInteractionCSS>
               <Suspense fallback={<div></div>}>


### PR DESCRIPTION
## Description
- focus improvement/child proposal if is edited
- scroll to node only for the first call to temporal node
- don't scroll to node while users edits proposals

Ref #409 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
