### PR TITLE
fixed the marginTop for tags in searcher

### DIFF
--- a/src/components/map/Sidebar/SidebarV2/SearcherSidebar.tsx
+++ b/src/components/map/Sidebar/SidebarV2/SearcherSidebar.tsx
@@ -336,7 +336,7 @@ const SearcherSidebar = ({ openLinkedNode, open, onClose }: SearcherSidebarProps
               }}
             />
           </div>
-          <div id="SearchTagsContainer">
+          <Box sx={{ marginTop: { xs: "13px", sm: "8px" } }}>
             <label className="Tooltip">
               {/* <input
               name="OnlyTagsNodes"
@@ -370,7 +370,7 @@ const SearcherSidebar = ({ openLinkedNode, open, onClose }: SearcherSidebarProps
                 Recover Default Tag(s)
               </span>
             )}
-          </div>
+          </Box>
           <div
             id="nodesUpdatedSinceContainer"
             style={{


### PR DESCRIPTION
## Description

Fixed the marginTop for tags in searcher.

Ref #479 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
