### PR TITLE
proposal reason reset

### DIFF
--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -500,6 +500,7 @@ const Node = ({
   useEffect(() => {
     if (editable) {
       setOpenPart("References");
+      setReason("");
       cleanEditorLink();
     }
   }, [editable]);

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -2850,10 +2850,10 @@ const Dashboard = ({}: DashboardProps) => {
         isTheSame = isTheSame && compareProperty(oldNode, newNode, "nodeImage");
         // isTheSame = compareLinks(oldNode.tags, newNode.tags, isTheSame, false)
         // isTheSame = compareLinks(oldNode.references, newNode.references, isTheSame, false)
-        isTheSame = isTheSame && compareFlatLinks(oldNode.tagIds, newNode.tagIds, isTheSame); // CHECK: O checked only ID changes
-        isTheSame = isTheSame && compareFlatLinks(oldNode.referenceIds, newNode.referenceIds, isTheSame); // CHECK: O checked only ID changes
-        isTheSame = isTheSame && compareLinks(oldNode.parents, newNode.parents, isTheSame, false);
-        isTheSame = isTheSame && compareLinks(oldNode.children, newNode.children, isTheSame, false);
+        isTheSame = compareFlatLinks(oldNode.tagIds, newNode.tagIds, isTheSame); // CHECK: O checked only ID changes
+        isTheSame = compareFlatLinks(oldNode.referenceIds, newNode.referenceIds, isTheSame); // CHECK: O checked only ID changes
+        isTheSame = compareLinks(oldNode.parents, newNode.parents, isTheSame, false);
+        isTheSame = compareLinks(oldNode.children, newNode.children, isTheSame, false);
 
         isTheSame = compareChoices(oldNode, newNode, isTheSame);
         if (isTheSame) {


### PR DESCRIPTION
## Description

Reason was not getting resetted when you close the proposal form.

Ref #501 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
