### PR TITLE
In Safari, in the toolbar, the trophy overlaps the leaderboard. Please make sure it looks the same in all major browsers.

### DIFF
--- a/src/components/map/Sidebar/SidebarV2/ToolbarSidebar.tsx
+++ b/src/components/map/Sidebar/SidebarV2/ToolbarSidebar.tsx
@@ -37,6 +37,12 @@ type MainSidebarProps = {
   pendingProposalsNum: number;
 };
 
+// TODO:
+// create a utils function to detect OS and Browser
+// for using cross browser functionality issues
+const isSafari =
+  typeof window === "undefined" ? false : /^((?!chrome|android).)*safari/i.test(window.navigator.userAgent);
+
 export const ToolbarSidebar = ({
   open,
   onClose,
@@ -646,7 +652,7 @@ MainSidebarProps) => {
                 </>
               )}
             </Box>
-            <Box sx={{ height: "calc(100vh - 400px)", paddingBottom: "20px" }}>
+            <Box sx={{ height: "calc(100vh - 400px)", paddingBottom: "20px", marginTop: isSafari ? "20px" : "" }}>
               {user?.tag && leaderboardType && (
                 <UsersStatusList
                   // reputationsLoaded={props.reputationsLoaded}

--- a/src/components/map/Sidebar/SidebarV2/ToolbarSidebar.tsx
+++ b/src/components/map/Sidebar/SidebarV2/ToolbarSidebar.tsx
@@ -255,9 +255,17 @@ MainSidebarProps) => {
             className="toolbar"
             sx={{ overflow: "hidden", display: { xs: isMenuOpen ? "block" : "none", sm: "block" } }}
           >
+            {/* IMPORTANT : if you modify the height you must modify the Box below  */}
+
             <Box
               // className="toolbar-options"
-              sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "10px", height: "376px" }}
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "10px",
+                height: isSafari ? "400px" : "376px",
+              }}
             >
               <Box sx={{ marginTop: "20px" }}>
                 <MemoizedMetaButton
@@ -652,7 +660,7 @@ MainSidebarProps) => {
                 </>
               )}
             </Box>
-            <Box sx={{ height: "calc(100vh - 400px)", paddingBottom: "20px", marginTop: isSafari ? "20px" : "" }}>
+            <Box sx={{ height: isSafari ? "calc(100vh - 400px)" : "calc(100vh - 375px)", paddingBottom: "20px" }}>
               {user?.tag && leaderboardType && (
                 <UsersStatusList
                   // reputationsLoaded={props.reputationsLoaded}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Ref #458 [In Safari, in the toolbar, the trophy overlaps the leaderboard. Please make sure it looks the same in all major browsers.·](https://github.com/ImanYZ/1Cademy-Public/issues/504)
![image](https://user-images.githubusercontent.com/62210295/200199015-dec88901-8460-44ac-a879-7d5b090452c8.png)

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
