### PR TITLE
Fix/focus input searcher after opening searcher sidebar

### DIFF
--- a/src/components/map/Sidebar/SidebarV2/SearcherSidebar.tsx
+++ b/src/components/map/Sidebar/SidebarV2/SearcherSidebar.tsx
@@ -70,7 +70,6 @@ const SearcherSidebar = ({ openLinkedNode, open, onClose, innerHeight }: Searche
   const [sortDirection, setSortDirection] = useState<SortDirection>("DESCENDING");
   const [chosenTags, setChosenTags] = useState<ChosenTag[]>([]);
   const [search, setSearch] = useState<string>(nodeBookState.searchQuery);
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isPending, startTransition] = useTransition();
 
@@ -80,6 +79,15 @@ const SearcherSidebar = ({ openLinkedNode, open, onClose, innerHeight }: Searche
     totalPage: 0,
     totalResults: 0,
   });
+
+  const onFocusSearcherInput = useCallback(
+    (inputTitle: HTMLElement) => {
+      if (!open) return;
+      if (!inputTitle) return;
+      inputTitle.focus();
+    },
+    [open]
+  );
 
   const getTagsSelected = useCallback<() => TagTreeView[]>(
     () => Object.values(allTags).filter(tag => tag.checked),
@@ -324,6 +332,7 @@ const SearcherSidebar = ({ openLinkedNode, open, onClose, innerHeight }: Searche
                     </IconButton>
                   </InputAdornment>
                 ),
+                inputRef: onFocusSearcherInput,
               }}
             />
           </div>


### PR DESCRIPTION
## Description
- implement `onFocusSearcherInput` useCallback function, and pass as `inputRef` prop to `ValidatedInput` Component

Ref #806 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
