### PR TITLE
Lighter the color of first hr line below the node footer buttons in d…

### DIFF
--- a/src/components/map/LinkingWords/LinkingWords.tsx
+++ b/src/components/map/LinkingWords/LinkingWords.tsx
@@ -160,7 +160,8 @@ const LinkingWords = (props: LinkingWordsProps) => {
       <Box
         sx={{
           mx: "10px",
-          borderTop: theme => (theme.palette.mode === "dark" ? "solid 1px #757171" : "solid 1px #484848"),
+          borderTop: theme =>
+            theme.palette.mode === "dark" ? `solid 1px ${theme.palette.common.borderColor}` : "solid 1px",
         }}
       />
       <div className="LinkingWordsContainer card-action">
@@ -313,7 +314,10 @@ const LinkingWords = (props: LinkingWordsProps) => {
 
         <Box
           className="LearnAfter"
-          sx={{ borderLeft: theme => (theme.palette.mode === "dark" ? "solid 1px #484848" : "solid 1px") }}
+          sx={{
+            borderLeft: theme =>
+              theme.palette.mode === "dark" ? `solid 1px ${theme.palette.common.borderColor}` : "solid 1px",
+          }}
         >
           {props.openPart === "References" && (
             //StyleRef, f-size from Map.css ln 71

--- a/src/components/map/LinkingWords/LinkingWords.tsx
+++ b/src/components/map/LinkingWords/LinkingWords.tsx
@@ -157,7 +157,12 @@ const LinkingWords = (props: LinkingWordsProps) => {
 
   return props.openPart === "LinkingWords" || props.openPart === "Tags" || props.openPart === "References" ? (
     <>
-      <Box sx={{ mx: "10px", borderTop: "solid 1px #484848" }} />
+      <Box
+        sx={{
+          mx: "10px",
+          borderTop: theme => (theme.palette.mode === "dark" ? "solid 1px #757171" : "solid 1px #484848"),
+        }}
+      />
       <div className="LinkingWordsContainer card-action">
         <Box className="LearnBefore" sx={{ borderRight: "solid 1px" }}>
           {props.openPart === "LinkingWords" && (
@@ -306,7 +311,10 @@ const LinkingWords = (props: LinkingWordsProps) => {
 
         {/* <Box sx={{ mx: "10px", borderLeft: "solid 1px" }} /> */}
 
-        <Box className="LearnAfter" sx={{ borderLeft: "solid 1px" }}>
+        <Box
+          className="LearnAfter"
+          sx={{ borderLeft: theme => (theme.palette.mode === "dark" ? "solid 1px #484848" : "solid 1px") }}
+        >
           {props.openPart === "References" && (
             //StyleRef, f-size from Map.css ln 71
             <Box sx={{ fontSize: "16px" }}>

--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -727,7 +727,17 @@ const Node = ({
           )}
           {editable && (
             <>
-              <Box sx={{ mx: "10px", borderTop: "solid 1px #484848" }} />
+              <Box
+                sx={{
+                  mx: "10px",
+                  borderTop: theme =>
+                    theme.palette.mode === "dark"
+                      ? openPart
+                        ? "solid 1px #484848"
+                        : "solid 1px #757171"
+                      : "solid 1px",
+                }}
+              />
               <Box
                 className="ProposalCommentSubmitButton"
                 sx={{
@@ -837,7 +847,13 @@ const Node = ({
       )}
       {openSidebar === "PROPOSALS" && nodeBookState.selectedNode == identifier ? (
         <>
-          <Box sx={{ mx: "10px", borderTop: "solid 1px" }} />
+          <Box
+            sx={{
+              mx: "10px",
+              borderTop: theme =>
+                theme.palette.mode === "dark" ? (openPart ? "solid 1px #484848" : "solid 1px #757171") : "solid 1px",
+            }}
+          />
           <Box sx={{ p: "13px 10px" }}>
             <Box
               sx={{

--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -731,11 +731,7 @@ const Node = ({
                 sx={{
                   mx: "10px",
                   borderTop: theme =>
-                    theme.palette.mode === "dark"
-                      ? openPart
-                        ? "solid 1px #484848"
-                        : "solid 1px #757171"
-                      : "solid 1px",
+                    theme.palette.mode === "dark" ? `solid 1px ${theme.palette.common.borderColor}` : "solid 1px",
                 }}
               />
               <Box
@@ -851,7 +847,7 @@ const Node = ({
             sx={{
               mx: "10px",
               borderTop: theme =>
-                theme.palette.mode === "dark" ? (openPart ? "solid 1px #484848" : "solid 1px #757171") : "solid 1px",
+                theme.palette.mode === "dark" ? `solid 1px ${theme.palette.common.borderColor}` : "solid 1px",
             }}
           />
           <Box sx={{ p: "13px 10px" }}>

--- a/src/lib/theme/brandingTheme.ts
+++ b/src/lib/theme/brandingTheme.ts
@@ -12,6 +12,7 @@ declare module "@mui/material/styles/createPalette" {
     orangeDark: string;
     darkGrayBackground: string;
     gray: string;
+    borderColor: string;
   }
 }
 
@@ -23,6 +24,7 @@ const common = {
   orangeDark: "#ff6d00",
   darkGrayBackground: "#28282A",
   gray: "#D3D3D3",
+  borderColor: "#585858",
 };
 
 const systemFont = ["Roboto", "sans-serif"];


### PR DESCRIPTION

## Description

- Lighter the color of the first hr line below the node footer buttons in dark mode
- Darker the other hr lines below the first line in dark mode

Ref #906 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
