### PR TITLE
Fixed missed and wrong spelling issue in instructors setting page

### DIFF
--- a/src/components/instructors/setting/Vote.tsx
+++ b/src/components/instructors/setting/Vote.tsx
@@ -73,8 +73,8 @@ const Vote: FC<Props> = ({ semester, inputsHandler }) => {
                     borderBottom: "orange",
                   }}
                 />
-                &nbsp; by casting on other's proposals, which is in agreement with the instructors(s)' vote on the same
-                proposal.
+                &nbsp; by casting votes on others' proposals, which is in agreement with the instructors(s)' vote on the
+                same proposal.
               </Typography>
             </Box>
             <Box sx={{ display: "flex", flexWrap: "wrap", alignContent: "center", alignItems: "baseline" }}>
@@ -109,8 +109,8 @@ const Vote: FC<Props> = ({ semester, inputsHandler }) => {
                     borderBottom: "orange",
                   }}
                 />
-                &nbsp; by casting on other's proposals, which is in disagreement with the instructors(s)' vote on the
-                same proposal.
+                &nbsp; by casting votes on others' proposals, which is in disagreement with the instructors(s)' vote on
+                the same proposal.
               </Typography>
             </Box>
           </Box>


### PR DESCRIPTION
## Description

- Fixed missed and wrong spelling issues on the instructors setting page

Ref #823 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
