### PR TITLE
rateVersion use nodeType of version collection

### DIFF
--- a/src/pages/api/rateVersion.ts
+++ b/src/pages/api/rateVersion.ts
@@ -215,7 +215,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         nodeId: req.body.nodeId,
         nodeData,
         nodeRef,
-        nodeType: req.body.nodeType,
+        nodeType: nodeType,
         versionId: req.body.versionId,
         versionData,
         newVersion: false,


### PR DESCRIPTION
## Description

rateVersion use nodeType of version collection. It was using req.body.nodeType which was coming up as childType if childType was existed in version document

Ref #1082 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
