### PR TITLE
Removed child nodes buttons from reference type node

### DIFF
--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -1067,7 +1067,11 @@ const Node = ({
               />
               <div
                 id="ProposalButtonsRow"
-                style={{ border: "solid 0px pink", display: "flex", justifyContent: "space-around" }}
+                style={{
+                  border: "solid 0px pink",
+                  display: nodeType !== "Reference" ? "flex" : "none",
+                  justifyContent: "space-around",
+                }}
               >
                 {(Object.keys(proposedChildTypesIcons) as ProposedChildTypesIcons[]).map(
                   (childNodeType: ProposedChildTypesIcons) => {


### PR DESCRIPTION
## Description

- Removed child nodes buttons from reference type node

Ref #1159 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
