### PR TITLE
Removed padding from top when node is in editable mode

### DIFF
--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -573,15 +573,10 @@ const Node = ({
       }}
     >
       {/* INFO: uncomment this only on develope */}
-      {process.env.NODE_ENV === "development" && identifier}
+
       {open ? (
         <>
-          <div
-            className="card-content"
-            style={{
-              marginTop: "10px",
-            }}
-          >
+          <div className="card-content">
             <div className="card-title" data-hoverable={true}>
               {editable && isNew && (
                 <>
@@ -611,7 +606,7 @@ const Node = ({
                     justifyContent: "end",
                     alignItems: "center",
                     position: "relative",
-                    top: "-10px",
+                    top: "-5px",
                   }}
                 >
                   <Typography


### PR DESCRIPTION
## Description

- Removed padding from the top when a node is in editable mode

Ref #1217 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
