### PR TITLE
Revert node type icon position and make page url input focused when a…

### DIFF
--- a/src/components/map/LinkingWords/ReferenceLabelInput.tsx
+++ b/src/components/map/LinkingWords/ReferenceLabelInput.tsx
@@ -35,6 +35,7 @@ export const ReferenceLabelInput = ({
         fullWidth
         size="small"
         sx={sx}
+        autoFocus={true}
       />
     </>
   );

--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -578,12 +578,6 @@ const Node = ({
 
       {open ? (
         <>
-          {locked && <NodeTypeIcon nodeType={"locked"} tooltipPlacement={"top"} fontSize={"inherit"} />}
-          {!locked && (
-            <Box sx={{ margin: "5px 0px 0px 13px", padding: "0px" }}>
-              <NodeTypeIcon nodeType={nodeType} tooltipPlacement={"top"} fontSize={"inherit"} />
-            </Box>
-          )}
           <div className="card-content">
             <div className="card-title" data-hoverable={true}>
               {editable && isNew && (

--- a/src/components/map/NodeFooter.tsx
+++ b/src/components/map/NodeFooter.tsx
@@ -38,6 +38,7 @@ import shortenNumber from "../../lib/utils/shortenNumber";
 import { FullNodeData, OpenPart } from "../../nodeBookTypes";
 import LeaderboardChip from "../LeaderboardChip";
 import { MemoizedHeadlessLeaderboardChip } from "../map/FocusedNotebook/HeadlessLeaderboardChip";
+import NodeTypeIcon from "../NodeTypeIcon";
 import { ContainedButton } from "./ContainedButton";
 import { MemoizedMetaButton } from "./MetaButton";
 import { MemoizedNodeTypeSelector } from "./Node/NodeTypeSelector";
@@ -438,13 +439,17 @@ const NodeFooter = ({
           >
             {/* <NodeTypeIcon nodeType={nodeType} /> */}
 
-            {!locked && editable && (
-              <MemoizedNodeTypeSelector nodeId={identifier} setNodeParts={setNodeParts} nodeType={nodeType} />
-            )}
+            {locked && <NodeTypeIcon nodeType={"locked"} tooltipPlacement={"top"} fontSize={"inherit"} />}
+            {!locked &&
+              (editable ? (
+                <MemoizedNodeTypeSelector nodeId={identifier} setNodeParts={setNodeParts} nodeType={nodeType} />
+              ) : (
+                <NodeTypeIcon nodeType={nodeType} tooltipPlacement={"top"} fontSize={"inherit"} />
+              ))}
             <Tooltip
               title={`This node was last edited at ${dayjs(new Date(changedAt)).hour()}:${dayjs(
                 new Date(changedAt)
-              ).minute()}:${dayjs(new Date(changedAt)).second()} on ${dayjs(new Date(changedAt)).day()}/${
+              ).minute()}:${dayjs(new Date(changedAt)).second()} on ${dayjs(new Date(changedAt)).day() + 1}/${
                 dayjs(new Date(changedAt)).month() + 1
               }/${dayjs(new Date(changedAt)).year()}`}
               placement={"top"}
@@ -497,7 +502,9 @@ const NodeFooter = ({
                             ? theme.palette.common.darkBackground2
                             : theme.palette.common.lightBackground2,
                       },
-                      padding: "7px 0px",
+                      padding: "7px 7px",
+                      minWidth: "30px",
+                      height: "30px",
                     }}
                   >
                     <Box sx={{ display: "flex", alignItems: "center", gap: "4px", fill: "inherit" }}>

--- a/src/global.css
+++ b/src/global.css
@@ -223,7 +223,7 @@
   margin: 0px;
 }
 .card .card-content {
-  margin: -8px 13px 0px 13px !important;
+  margin: 13px 13px 0px 13px !important;
 }
 .card-title .CodeMirror {
   font-size: 25px;


### PR DESCRIPTION

## Description

- Revert node type icon position and make page URL input focused when adding any citation

Ref #1224 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
