### PR TITLE
Fixed duplicate tagging bug in generateTagsOfTagsWithNodes

### DIFF
--- a/src/utils/version-helpers.ts
+++ b/src/utils/version-helpers.ts
@@ -965,8 +965,11 @@ export const generateTagsOfTagsWithNodes = async ({
     // pushing in _tagIds to process them after loop for next recursion
     _tagIds.push(tagId);
 
-    nodeUpdates.tagIds.push(tagId);
-    nodeUpdates.tags.push(nodes[tagId].title);
+    // only push tag to tagIds if it not already present
+    if (!nodeUpdates.tagIds.includes(tagId)) {
+      nodeUpdates.tagIds.push(tagId);
+      nodeUpdates.tags.push(nodes[tagId].title);
+    }
   }
 
   // loading more higher communities


### PR DESCRIPTION
## Description

Fixed duplicate tagging bug in generateTagsOfTagsWithNodes

Ref #1346 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
