### PR TITLE
Now when open a new node the parent and children tab will open by default

### DIFF
--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -260,7 +260,7 @@ const Node = ({
   openUserInfoSidebar,
   disabled = false,
   enableChildElements = [],
-  defaultOpenPart: defaultOpenPartByTutorial = null,
+  defaultOpenPart: defaultOpenPartByTutorial = "LinkingWords",
   showProposeTutorial = false,
   setCurrentTutorial,
 }: NodeProps) => {


### PR DESCRIPTION
## Description

- Now when opening a new node the parent and children tab will open by default

Ref #1497 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
