### PR TITLE
Fix/tutorial tooltip target oversizes toolboox buttons mobile

### DIFF
--- a/src/lib/utils/tutorials/toolbooxTutorialSteps.tsx
+++ b/src/lib/utils/tutorials/toolbooxTutorialSteps.tsx
@@ -26,7 +26,7 @@ const FOCUS_MODE_STEPS_CONFIG: TutorialStepConfig[] = [
     description: (
       <MarkdownRender
         text={
-          "If you click this button it will change the presentation format. Rather than looking at a full graph of the nodes you have open, it will focus on one node at a time and prived a linear route of going to parent or child nodes one at a time."
+          "If you click this button it will change the presentation format. Rather than looking at a full graph of the nodes you have open, it will focus on one node at a time and provide a linear route of going to parent or child nodes one at a time."
         }
       />
     ),
@@ -62,7 +62,7 @@ const SCROLL_TO_NODE_STEPS_CONFIG: TutorialStepConfig[] = [
     description: (
       <MarkdownRender
         text={
-          "If you click this button it will automatically scroll to the last node that you interacted with. This can help you find where you previously where if you get a little lost while navigating around nodes."
+          "If you click this button it will automatically scroll to the last node that you interacted with. This can help you find where you previously were if you get a little lost while navigating around nodes."
         }
       />
     ),

--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -5718,7 +5718,7 @@ const Dashboard = ({}: DashboardProps) => {
                 sx={{
                   width: "100%",
                   display: "flex",
-                  justifyContent: "flex-start",
+                  justifyContent: "space-evenly",
                   alignItems: "center",
                   gap: {
                     xs: "5px",
@@ -5772,6 +5772,7 @@ const Dashboard = ({}: DashboardProps) => {
                       background: theme.palette.mode === "dark" ? "#404040" : "#EAECF0",
                       borderRadius: "8px",
                     },
+                    padding: { xs: "2px", sm: "8px" },
                   }}
                 >
                   <IconButton
@@ -5796,6 +5797,7 @@ const Dashboard = ({}: DashboardProps) => {
                       background: theme.palette.mode === "dark" ? "#404040" : "#EAECF0",
                       borderRadius: "8px",
                     },
+                    padding: { xs: "2px", sm: "8px" },
                   }}
                 >
                   <IconButton
@@ -5820,6 +5822,7 @@ const Dashboard = ({}: DashboardProps) => {
                       background: theme.palette.mode === "dark" ? "#404040" : "#EAECF0",
                       borderRadius: "8px",
                     },
+                    padding: { xs: "2px", sm: "8px" },
                   }}
                 >
                   <IconButton
@@ -5854,6 +5857,7 @@ const Dashboard = ({}: DashboardProps) => {
                         background: theme.palette.mode === "dark" ? "#404040" : "#EAECF0",
                         borderRadius: "8px",
                       },
+                      padding: { xs: "2px", sm: "8px" },
                     }}
                   >
                     {/* DEVTOOLS */}

--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -5757,6 +5757,7 @@ const Dashboard = ({}: DashboardProps) => {
                     disabled={!nodeBookState.selectedNode ? true : false}
                     sx={{
                       opacity: !nodeBookState.selectedNode ? 0.5 : undefined,
+                      padding: { xs: "2px", sm: "8px" },
                     }}
                   >
                     <MyLocationIcon sx={{ color: theme => (theme.palette.mode === "dark" ? "#CACACA" : "#667085") }} />


### PR DESCRIPTION
## Description

- reduce target padding for mobile view
- update toolbox tutorials' spelling
- justify evenly toolbox buttons

Ref #1640 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
