### PR TITLE
fix blicking border when a temporal edit tutorial is removed

### DIFF
--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -5289,6 +5289,7 @@ const Dashboard = ({}: DashboardProps) => {
       const node = graph.nodes[targetId];
       if (!tmpEditNodeIsValid(node)) {
         setTutorial(null);
+        if (currentStep?.childTargetId) removeStyleFromTarget(currentStep.childTargetId, targetId);
         if (node && node.editable) return;
 
         setForcedTutorial(null);


### PR DESCRIPTION
## Description

remove blinking border after remove temporal edit tutorial

Ref #1694 
## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
