### PR TITLE
Now open all parent/chidlren button will not show on new child node

### DIFF
--- a/src/components/map/LinkingWords/LinkingWords.tsx
+++ b/src/components/map/LinkingWords/LinkingWords.tsx
@@ -236,19 +236,20 @@ const LinkingWords = ({
                   </Box>
                 );
               })}
-
-              <Button
-                onClick={() => props.openAllParent(props.identifier)}
-                sx={{
-                  justifyContent: "stretch",
-                  textAlign: "left",
-                  ":hover": {
-                    background: "transparent",
-                  },
-                }}
-              >
-                Open All Parents
-              </Button>
+              {props.parents.length > 0 && !props.isNew && (
+                <Button
+                  onClick={() => props.openAllParent(props.identifier)}
+                  sx={{
+                    justifyContent: "stretch",
+                    textAlign: "left",
+                    ":hover": {
+                      background: "transparent",
+                    },
+                  }}
+                >
+                  Open All Parents
+                </Button>
+              )}
 
               {props.editable && !props.isNew && notebookRef.current.selectedNode === props.identifier && (
                 <MemoizedMetaButton
@@ -542,18 +543,20 @@ const LinkingWords = ({
                   </Box>
                 );
               })}
-              <Button
-                onClick={() => props.openAllChildren(props.identifier)}
-                sx={{
-                  justifyContent: "stretch",
-                  textAlign: "left",
-                  ":hover": {
-                    background: "transparent",
-                  },
-                }}
-              >
-                Open All Children
-              </Button>
+              {props.nodesChildren.length > 0 && !props.isNew && (
+                <Button
+                  onClick={() => props.openAllChildren(props.identifier)}
+                  sx={{
+                    justifyContent: "stretch",
+                    textAlign: "left",
+                    ":hover": {
+                      background: "transparent",
+                    },
+                  }}
+                >
+                  Open All Children
+                </Button>
+              )}
               {props.editable &&
                 !props.isNew &&
                 props.nodeType !== "Reference" &&


### PR DESCRIPTION
## Description

- Now open all parent/children button will not show on the new child node

Ref #1637 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
