### PR TITLE
Fix/hide descendants

### DIFF
--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -115,7 +115,6 @@ import {
   createActionTrack,
   generateReputationSignal,
   getSelectionText,
-  hideNodeAndItsLinks,
   NODE_WIDTH,
   removeDagAllEdges,
   removeDagEdge,
@@ -1759,7 +1758,7 @@ const Dashboard = ({}: DashboardProps) => {
                 createdAt: Timestamp.fromDate(new Date()),
               };
               const changeNode: any = {
-                viewers: (thisNode.viewers || 0) - 1, // CHECK I add 0
+                viewers: (thisNode.viewers || 0) - 1,
                 updatedAt: Timestamp.fromDate(new Date()),
               };
               if (userNodeData.open && "openHeight" in thisNode) {
@@ -1777,12 +1776,6 @@ const Dashboard = ({}: DashboardProps) => {
 
             await batch.commit();
 
-            // TODO: need to discuss about these
-            let oldNodes = { ...graph.nodes };
-            let oldEdges = { ...graph.edges };
-            for (let descendant of descendants) {
-              ({ oldNodes, oldEdges } = hideNodeAndItsLinks(g.current, descendant, oldNodes, oldEdges, updatedNodeIds));
-            }
             setNodeUpdates({
               nodeIds: updatedNodeIds,
               updatedAt: new Date(),


### PR DESCRIPTION
## Description

- remove hideNodeAndItsLinks util function, because its purpose is about to update dagger ref, it's no use ever since dagger gets updated in the snapshot listener.

Ref #1782 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
