### PR TITLE
add scroll to node when open a node from practice tool

### DIFF
--- a/src/components/practiceTool/PracticeQuestion.tsx
+++ b/src/components/practiceTool/PracticeQuestion.tsx
@@ -589,7 +589,7 @@ export const PracticeQuestion = ({
                     },
                   }}
                 >
-                  View Node Tree
+                  Open this in Notebook
                 </Button>
                 {!submitAnswer && (
                   <Button

--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -6634,7 +6634,7 @@ const Notebook = ({}: NotebookProps) => {
                 router.replace(router.pathname);
                 setVoiceAssistant(null);
               }}
-              openNodeHandler={openNodeHandler}
+              openNodeHandler={openLinkedNode}
               sx={{ position: "absolute", inset: "0px", zIndex: 999 }}
               root={rootQuery}
               startPractice={startPractice}


### PR DESCRIPTION
## Description

- scroll to node when a node is opened from practice tool 
- change "View Node Tree" --> "Open this in Notebook" 

Ref #2032
## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
