### PR TITLE
Feature/leadeboard is not ordered based on their practice points

### DIFF
--- a/src/components/practiceTool/Leaderboard.tsx
+++ b/src/components/practiceTool/Leaderboard.tsx
@@ -62,8 +62,9 @@ const Leaderboard = ({ semesterId, sxBody }: LeaderboardProps) => {
 
   useEffect(() => {
     const res = mapSemesterStudentVoteStatToLeaderboard(studentStatsBySemester, selectedLeaderboardOption);
-    console.log("2ress", { res });
-    setLeaderBoardUSers(res);
+    const resSortedByPoints = res.sort((a, b) => b.totalPoints - a.totalPoints);
+    console.log("2ress", { resSortedByPoints });
+    setLeaderBoardUSers(resSortedByPoints);
   }, [selectedLeaderboardOption, studentStatsBySemester]);
 
   return (
@@ -304,9 +305,9 @@ const mapSemesterStudentVoteStatToLeaderboard = (
   // move to backend to not get unused data
   return stats.map(cur => {
     const statDaysFiltered = filterDaysStatsByOption(option, cur.days);
-    console.log({ statDaysFiltered });
+    // console.log({ statDaysFiltered });
     const totalPoints = statDaysFiltered.reduce((acu, cur) => acu + (cur?.totalPractices ?? 0), 0);
-    console.log({ totalPoints });
+    // console.log({ totalPoints });
     return { uname: cur.uname, totalPoints };
   });
 };


### PR DESCRIPTION
## Description

fix users order on leaderboard on practice tool

Ref #2040 
## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
