### PR TITLE
render node titles as markdown when user zoom out

### DIFF
--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -43,6 +43,7 @@ import { TNodeBookState } from "../../nodeBookTypes";
 import { NodeType } from "../../types";
 // import { FullNodeData } from "../../noteBookTypes";
 import { Editor } from "../Editor";
+import MarkdownRender from "../Markdown/MarkdownRender";
 import NodeTypeIcon from "../NodeTypeIcon2";
 // import LeaderboardChip from "../LeaderboardChip";
 // import NodeTypeIcon from "../NodeTypeIcon";
@@ -849,15 +850,10 @@ const Node = ({
             },
           }}
         >
-          <Typography
-            component={"p"}
-            fontSize={`${14 / 0.32}px`}
-            fontWeight={500}
-            textAlign={"center"}
-            textOverflow={"ellipsis"}
-          >
-            {title}
-          </Typography>
+          <MarkdownRender
+            text={titleCopy}
+            sx={{ fontSize: "25px", fontWeight: 500, textAlign: "center", textOverflow: "ellipsis" }}
+          />
           <NodeTypeIcon
             nodeType={nodeType}
             tooltipPlacement="bottom"


### PR DESCRIPTION
## Description

display node title when is zoom out as Markdown

Ref #2337

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
