### PR TITLE
display title node correctly when user makes zoom out

### DIFF
--- a/src/components/map/Node.tsx
+++ b/src/components/map/Node.tsx
@@ -850,10 +850,28 @@ const Node = ({
             },
           }}
         >
-          <MarkdownRender
-            text={titleCopy}
-            sx={{ fontSize: "25px", fontWeight: 500, textAlign: "center", textOverflow: "ellipsis" }}
-          />
+          {proposalsSelected && (
+            <Box
+              dangerouslySetInnerHTML={{ __html: titleCopy }}
+              sx={{
+                fontSize: "25px",
+                fontWeight: 500,
+                textAlign: "center",
+                textOverflow: "ellipsis",
+              }}
+            />
+          )}
+          {!proposalsSelected && (
+            <MarkdownRender
+              text={titleCopy}
+              sx={{
+                fontSize: "25px",
+                fontWeight: 500,
+                textAlign: "center",
+                textOverflow: "ellipsis",
+              }}
+            />
+          )}
           <NodeTypeIcon
             nodeType={nodeType}
             tooltipPlacement="bottom"


### PR DESCRIPTION
## Description

display titles correctly when user makes zoom out and select a proposal

Ref #2337

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
