### PR TITLE
make the personal and Education section optional in the signup page

### DIFF
--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -146,10 +146,10 @@ const SignUpPage: NextPageWithLayout = () => {
       is: (foundFromValue: string) => foundFromValue === "Not listed (Please specify)",
       then: yup.string().required("Required"),
     }),
-    occupation: yup.string().required("Please enter your occupation"),
-    education: yup.string().required("Please enter your educational status").nullable(true),
+    // occupation: yup.string().required("Please enter your occupation"),
+    // education: yup.string().required("Please enter your educational status").nullable(true),
     institution: yup.string().required("Please enter your institution").nullable(),
-    major: yup.string().required("Please enter your major").nullable(),
+    // major: yup.string().required("Please enter your major").nullable(),
     // fieldOfInterest: yup.string().required("Please enter your field of interest"),
     signUpAgreement: yup.boolean().isTrue("Please accept the Informed Consent to continue"),
     GDPRPolicyAgreement: yup.boolean().isTrue("Please accept the GDPR Policy to continue"),
@@ -259,7 +259,12 @@ const SignUpPage: NextPageWithLayout = () => {
       Boolean(formik.errors.username) ||
       Boolean(formik.errors.password) ||
       Boolean(formik.errors.passwordConfirmation) ||
-      !Boolean(formik.values.firstName)
+      !Boolean(formik.values.firstName) ||
+      !Boolean(formik.values.cookiesAgreement) ||
+      !Boolean(formik.values.privacyPolicyAgreement) ||
+      !Boolean(formik.values.GDPRPolicyAgreement) ||
+      !Boolean(formik.values.termsOfServiceAgreement) ||
+      !Boolean(formik.values.signUpAgreement)
     );
   };
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Ref #2346

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
