### PR TITLE
Canonical Alt added for Search Console

### DIFF
--- a/src/components/NodeHead.tsx
+++ b/src/components/NodeHead.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import { useEffect, useState } from "react";
 
 import { APP_DOMAIN } from "@/lib/utils/1cademyConfig";
 import { escapeBreaksQuotes, getNodePageWithDomain } from "@/lib/utils/utils";
@@ -102,9 +103,19 @@ export const NodeHead = ({ node, keywords, updatedStr, createdStr }: NodeHeadPro
         ${content} Keywords: ${title} ${keywords} ${nodeImage ? "\nImage: " + nodeImage : ""}
       `);
 
+  const [currentUrl, setCurrentUrl] = useState<string>("");
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setCurrentUrl(window.location.href);
+  }, [setCurrentUrl]);
+
+  const nodeUrl = getNodePageWithDomain(title || "", id);
+  const hasAltCanonical = currentUrl && nodeUrl !== currentUrl;
+
   return (
     <Head>
-      <link rel="canonical" href={`${getNodePageWithDomain(title || "", id)}`} key="canonical" />
+      <link rel="canonical" href={`${nodeUrl}`} key="canonical" />
+      {hasAltCanonical ? <link rel="canonical" href={`${currentUrl}`} key="canonical-alt" /> : <></>}
       <meta name="topic" content={`1Cademy - ${escapeBreaksQuotes(title)}`} />
       <meta name="subject" content={`1Cademy - ${escapeBreaksQuotes(title)}`} />
       <meta name="Classification" content={nodeType} />

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -59,6 +59,7 @@ export const Home = () => {
     <>
       <Head>
         <link rel="canonical" href={`${ONECADEMY_DOMAIN}`} key="canonical" />
+        <link rel="canonical" href="https://www.1cademy.com/" key="canonical-alt" />
         <title>1Cademy</title>
       </Head>
       <Box


### PR DESCRIPTION
## Description

I have added canonical meta for old node url

Ref #2459 

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
