### PR TITLE
Added middleware that will change status 302 to 301 and make http to https

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const url = new URL(req.url);
+  if (url.protocol === "http:" || url.hostname.startsWith("www.")) {
+    if (req.url.includes("notebook")) {
+      const httpsUrl = `https://${url.host}${url.pathname}${url.search}${url.hash}`;
+      console.log(httpsUrl, "httpsUrl");
+      return NextResponse.redirect(httpsUrl, {
+        status: 301,
+        headers: {
+          ...req.headers,
+        },
+      });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Skip all paths that should not be internationalized. This example skips the
+  // folders "api", "_next" and all files with an extension (e.g. favicon.ico)
+  matcher: ["/((?!api|_next|.*\\..*).*)"],
+};


### PR DESCRIPTION


## Description

- Added middleware that will change status 302 to 301 and make HTTP to HTTPS

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
