### PR TITLE
Updated status docs to have sessions list with last activity timestamps instead of session id alone

### DIFF
--- a/cloud-functions/package-lock.json
+++ b/cloud-functions/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "firebase-functions": "^4.0.1"
+        "firebase-functions": "^4.0.1",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@babel/parser": {
@@ -1825,9 +1826,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -4503,9 +4502,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/cloud-functions/package.json
+++ b/cloud-functions/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "firebase-functions": "^4.0.1"
+    "firebase-functions": "^4.0.1",
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
## Description

- Modified the Cloud function to:
  - Utilize "Sessions" objects instead of using mere "session ids".
  - Enhanced the "Sessions" object to:
  - Include a "last activity" timestamp attribute.
- Developed a new Cloud function that:
  - Scans user status documents periodically.
  - Identifies "inactive" sessions based on "last activity".
  - Removes inactive sessions if they haven't been active for 30 minutes.
- Implemented an Interval Timer in the frontend application to:
  - Send updates to the server regarding user activity.
  - Refresh the "last activity" timestamp of the current session.
  - Trigger this update process at 2-minute intervals.

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
