### PR TITLE
Improve the CI-Ontology Page

### DIFF
--- a/src/components/ontology/SubOntology.tsx
+++ b/src/components/ontology/SubOntology.tsx
@@ -37,7 +37,7 @@ const SubOntology = ({
   };
 
   const removeSubOntology = ({ ontologyData, id }: any) => {
-    for (type in ontologyData.subOntologies) {
+    for (let type in ontologyData.subOntologies) {
       for (let category in ontologyData.subOntologies[type] || {}) {
         if ((ontologyData.subOntologies[type][category].ontologies || []).length > 0) {
           const subOntologyIdx = ontologyData.subOntologies[type][category].ontologies.findIndex(
@@ -52,7 +52,6 @@ const SubOntology = ({
   };
   const deleteSubOntologyEditable = async () => {
     try {
-      console.info("deleteSubOntologyEditable");
       if (await confirmIt("Are you sure you want to delete?")) {
         const ontologyDoc = await getDoc(doc(collection(db, "ontology"), openOntology.id));
         if (ontologyDoc.exists()) {

--- a/src/components/ontology/SubPlainText.tsx
+++ b/src/components/ontology/SubPlainText.tsx
@@ -17,6 +17,7 @@ type ISubOntologyProps = {
   addLock: any;
   user: any;
   recordLogs: any;
+  deleteSubOntologyEditable?: any;
 };
 const SubPlainText = ({
   text,
@@ -29,6 +30,7 @@ const SubPlainText = ({
   addLock,
   user,
   recordLogs,
+  deleteSubOntologyEditable = () => {},
 }: ISubOntologyProps) => {
   const db = getFirestore();
   const [editMode, setEditMode] = useState(false);
@@ -190,6 +192,11 @@ const SubPlainText = ({
                   </Button>
                 </Tooltip>
               )}
+              <Tooltip title={"Delete Ontology"} sx={{ ml: "5px" }}>
+                <Button onClick={deleteSubOntologyEditable} sx={{ ml: "5px" }}>
+                  Delete
+                </Button>
+              </Tooltip>
             </Box>
           )}
         </Box>

--- a/src/pages/CIOntology.tsx
+++ b/src/pages/CIOntology.tsx
@@ -660,28 +660,18 @@ const CIOntology = () => {
               key={mainSpecializations[category]?.id || category}
               nodeId={mainSpecializations[category]?.id || category}
               label={
-                <Box sx={{ display: "flex", alignItems: "center" }}>
-                  <Typography sx={{ fontWeight: mainSpecializations[category].isCategory ? "bold" : "" }}>
+                <Box sx={{ display: "flex", alignItems: "center", height: "30px" }}>
+                  <Typography
+                    sx={{ fontWeight: mainSpecializations[category].isCategory ? "bold" : "" }}
+                    onClick={() => {
+                      if (!mainSpecializations[category].isCategory)
+                        openMainCategory(category, mainSpecializations[category]?.path || []);
+                    }}
+                  >
                     {!mainSpecializations[category].isCategory
                       ? category.split(" ").splice(0, 3).join(" ") + (category.split(" ").length > 3 ? "..." : "")
                       : category}
                   </Typography>
-                  {!mainSpecializations[category].isCategory && (
-                    <Button
-                      variant="outlined"
-                      onClick={() => {
-                        openMainCategory(category, mainSpecializations[category]?.path || []);
-                      }}
-                      sx={{
-                        ml: "5px",
-                        fontSize: "14px",
-                        border: "none",
-                        background: "transparent",
-                      }}
-                    >
-                      Open
-                    </Button>
-                  )}
                 </Box>
               }
               sx={{ mt: "5px" }}


### PR DESCRIPTION
## Description

- Modify the left tree-view the way he explained. Clicking the object name should open its page. Clicking the carrot should expand/collapse it. 
- Add the delete button in the specialization page as well. It does not make sense to only delete a subclass from its parent's list of specializations.
- Every specialization should inherit its parent fields.

Please include a summary of the change and which issue is fixed.

Ref # (issue)

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
