### PR TITLE
Added multiple canonials if any node has multiple slugs and remove the tabs from searcher sidebar

### DIFF
--- a/src/components/NodeHead.tsx
+++ b/src/components/NodeHead.tsx
@@ -18,6 +18,7 @@ export const NodeHead = ({ node, keywords, updatedStr, createdStr }: NodeHeadPro
     id,
     title,
     nodeSlug,
+    nodeSlugs,
     parents = [],
     references = [],
     content,
@@ -112,10 +113,17 @@ export const NodeHead = ({ node, keywords, updatedStr, createdStr }: NodeHeadPro
 
   const nodeUrl = getNodePageWithDomain(nodeSlug || "", id, "slug");
   const hasAltCanonical = currentUrl && nodeUrl !== currentUrl;
-
   return (
     <Head>
-      <link rel="canonical" href={`${nodeUrl}`} key="canonical" />
+      {nodeSlugs && nodeSlugs.length > 0 ? (
+        nodeSlugs.map((slug: string) => {
+          const nodeUrl = getNodePageWithDomain(slug || "", id, "slug");
+          return <link rel="canonical" href={`${nodeUrl}`} key="canonical" />;
+        })
+      ) : (
+        <link rel="canonical" href={`${nodeUrl}`} key="canonical" />
+      )}
+
       {hasAltCanonical ? <link rel="canonical" href={`${currentUrl}`} key="canonical-alt" /> : <></>}
       <meta name="topic" content={`1Cademy - ${escapeBreaksQuotes(title)}`} />
       <meta name="subject" content={`1Cademy - ${escapeBreaksQuotes(title)}`} />

--- a/src/components/map/Sidebar/SidebarV2/SearcherSidebar.tsx
+++ b/src/components/map/Sidebar/SidebarV2/SearcherSidebar.tsx
@@ -15,8 +15,6 @@ import {
   Select,
   SelectChangeEvent,
   Stack,
-  Tab,
-  Tabs,
   Typography,
   useMediaQuery,
   useTheme,
@@ -97,7 +95,7 @@ const SearcherSidebar = ({
   const [sortDirection, setSortDirection] = useState<SortDirection>("DESCENDING");
   const [chosenTags, setChosenTags] = useState<ChosenTag[]>([]);
   const [search, setSearch] = useState<string>(nodeBookState.searchQuery);
-  const [value, setValue] = React.useState(0);
+  const [value] = React.useState(0);
   // const [notebooks, setNoteBooks] = useState<any>({
   //   data: [],
   //   lastPageLoaded: 0,
@@ -348,11 +346,11 @@ const SearcherSidebar = ({
     showTagSelector,
   ]);
 
-  const a11yProps = (index: number) => {
-    return {
-      "aria-controls": `simple-tabpanel-${index}`,
-    };
-  };
+  // const a11yProps = (index: number) => {
+  //   return {
+  //     "aria-controls": `simple-tabpanel-${index}`,
+  //   };
+  // };
   const handleChange = useCallback(
     (event: any) => {
       let val = event.target.value;
@@ -496,9 +494,9 @@ const SearcherSidebar = ({
     setShowTagSelector(false);
   }, [nodeBookDispatch]);
 
-  const handleTabValueChange = (event: React.SyntheticEvent, newValue: number) => {
-    setValue(newValue);
-  };
+  // const handleTabValueChange = (event: React.SyntheticEvent, newValue: number) => {
+  //   setValue(newValue);
+  // };
 
   const results = useMemo(() => {
     if (value === 0) {
@@ -892,19 +890,19 @@ const SearcherSidebar = ({
             width: "100%",
           }}
         >
-          <Tabs value={value} onChange={handleTabValueChange} aria-label={"Search Sidebar Tabs"} variant="fullWidth">
-            {[{ title: "Nodes" }, /* { title: "Notebooks" }, */ { title: "Proposals" }].map(
-              (tabItem: any, idx: number) => (
-                <Tab
-                  key={tabItem.title}
-                  id={`bookmarks-tab-${tabItem.title.toLowerCase()}`}
-                  label={tabItem.title}
-                  {...a11yProps(idx)}
-                  sx={{ py: "20px" }}
-                />
-              )
-            )}
-          </Tabs>
+          {/* <Tabs value={value} onChange={handleTabValueChange} aria-label={"Search Sidebar Tabs"} variant="fullWidth">
+            // {[{ title: "Nodes" }, { title: "Proposals" }].map(
+              // (tabItem: any, idx: number) => (
+              //   <Tab
+              //     key={tabItem.title}
+              //     id={`bookmarks-tab-${tabItem.title.toLowerCase()}`}
+              //     label={tabItem.title}
+              //     {...a11yProps(idx)}
+              //     sx={{ py: "20px" }}
+              //   />
+              // )
+            //</Box>)}
+          </Tabs> */}
         </Box>
       </Box>
     );

--- a/src/knowledgeTypes.ts
+++ b/src/knowledgeTypes.ts
@@ -120,6 +120,7 @@ export type NodeFireStore = {
   maxVersionRating?: number;
   nodeImage?: string;
   nodeSlug?: string;
+  nodeSlugs?: string[];
   nodeType: NodeType;
   parents?: { node?: string; label?: string; title?: string }[];
   referenceIds?: string[];


### PR DESCRIPTION

## Description

- Added multiple canonicals if any node has multiple slugs and removed the tabs from the searcher sidebar

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
