### PR TITLE
Increased the liveliness bar zIndex for hiding robot icon of extension when livebar open

### DIFF
--- a/src/components/map/Liveliness/LivelinessBar.tsx
+++ b/src/components/map/Liveliness/LivelinessBar.tsx
@@ -71,7 +71,7 @@ const LivelinessBar = ({ variant, onToggleDisplay, open, ...props }: ILiveliness
         bottom: "100px",
         right: "0px",
         p: `${USER_BUBBLE_SIZE / 2 + 20}px 10px`,
-        zIndex: 998,
+        zIndex: 1000,
         position: "absolute",
         width: "56px",
         background: theme =>


### PR DESCRIPTION


## Description

- Increased the liveliness bar zIndex for hiding the robot icon of extension when the live bar open

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
