### PR TITLE
Add flashcard reaction removal on delete

### DIFF
--- a/cloud-functions/functions/src/actions/removeReactionFromCard.ts
+++ b/cloud-functions/functions/src/actions/removeReactionFromCard.ts
@@ -1,0 +1,29 @@
+import { db } from "../admin";
+export const removeReactionFromCard = async (data: any) => {
+  try {
+    const doer = data.savedBy;
+    const flashcardId = data.cardId;
+    const documentId = data.passageId;
+
+    await db.runTransaction(async transaction => {
+      const bookDoc = await transaction.get(db.collection("chaptersBook").doc(documentId));
+      const bookData = bookDoc.data();
+      if (bookData) {
+        const flashcards = bookData.flashcards || [];
+
+        const flashcardIdx = flashcards.findIndex((f: any) => f.id === flashcardId);
+
+        if (flashcardIdx !== -1) {
+          if (flashcards[flashcardIdx].reactions && flashcards[flashcardIdx].reactions[doer]) {
+            delete flashcards[flashcardIdx].reactions[doer];
+          }
+          transaction.update(bookDoc.ref, { flashcards });
+        } else {
+          console.error("Flashcard not found");
+        }
+      }
+    });
+  } catch (error) {
+    console.log("removeReactionFromCard", error);
+  }
+};

--- a/cloud-functions/functions/src/index.ts
+++ b/cloud-functions/functions/src/index.ts
@@ -18,6 +18,7 @@ import { checkNeedsUpdates } from "./helpers/version-helpers";
 import { updatesNodeViewers } from "./actions/updatesNodeViewers";
 import { trigerNotifications } from "./actions/trigerNotifications";
 import { addUserToChannel } from "./actions/addUserToChannel";
+import { removeReactionFromCard } from "./actions/removeReactionFromCard";
 
 import { db } from "./admin";
 
@@ -270,6 +271,15 @@ export const onUserUpdate = functions.firestore.document("/users/{id}").onUpdate
   }
 });
 
+export const onDeleteSavedFlashcard = functions.firestore.document("/savedBookCards/{id}").onDelete(async change => {
+  try {
+    const changeData = change.data();
+    console.log(changeData);
+    removeReactionFromCard(changeData);
+  } catch (error) {
+    console.log("error onUserUpdate:", error);
+  }
+});
 exports.assignNodeContributorsInstitutionsStats = functions
   .runWith({ memory: "1GB", timeoutSeconds: 520 })
   .pubsub.schedule("every 25 hours")


### PR DESCRIPTION
Implemented a new cloud function to handle the deletion of reactions from a flashcard when the corresponding savedBookCards entry is deleted. This ensures that user reactions are removed effectively, maintaining data integrity and user experience when flashcards are no longer saved. The function executes within a transaction to ensure atomic updates to the flashcards within the chaptersBook collection. Additionally, registered this new cloud function to trigger upon the deletion event.

## Description

Please include a summary of the change and which issue is fixed.

Ref # (issue)

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
