### PR TITLE
fix a bug with the worker drawing the nodes when the user opens a child node

### DIFF
--- a/src/workers/MapWorker.ts
+++ b/src/workers/MapWorker.ts
@@ -124,6 +124,7 @@ const layoutHandler = (
       //  if the distance between the new edge and old edge is >= constant value MIN_CHANGE
       //  update the map's width and mapChangedFlag accordingly
       // console.log(thisNode, n, JSON.parse(JSON.stringify(thisNode)));
+      if (!thisNode) return null;
       if (
         !("left" in thisNode) ||
         !("top" in thisNode) ||


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Ref # (issue)

## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [ ] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
