### PR TITLE
Hide the liveliness bar and fixed the issue of "Tag it" Button not showing

### DIFF
--- a/src/components/map/Sidebar/SidebarV2/ToolbarSidebar.tsx
+++ b/src/components/map/Sidebar/SidebarV2/ToolbarSidebar.tsx
@@ -295,7 +295,11 @@ export const ToolbarSidebar = ({
 
   const choosingNodeClick = useCallback(
     (choosingNodeTag: string) => {
-      nodeBookDispatch({ type: "setChoosingNode", payload: { id: choosingNodeTag, type: null } });
+      notebookRef.current.choosingNode = { id: choosingNodeTag, type: "Tag" };
+      notebookRef.current.chosenNode = null;
+
+      nodeBookDispatch({ type: "setChosenNode", payload: null });
+      nodeBookDispatch({ type: "setChoosingNode", payload: { id: choosingNodeTag, type: "Tag" } });
     },
     [nodeBookDispatch]
   );
@@ -1097,7 +1101,7 @@ export const ToolbarSidebar = ({
                 sx={{
                   "&.MuiModal-root": {
                     top: "100px",
-                    left: "240px",
+                    left: "430px",
                     right: "unset",
                     bottom: "unset",
                   },

--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -68,9 +68,9 @@ import { INotificationNum } from "src/types/INotification";
 import withAuthUser from "@/components/hoc/withAuthUser";
 import { MemoizedCommunityLeaderboard } from "@/components/map/CommunityLeaderboard/CommunityLeaderboard";
 import { MemoizedFocusedNotebook } from "@/components/map/FocusedNotebook/FocusedNotebook";
-import { MemoizedLivelinessBar } from "@/components/map/Liveliness/LivelinessBar";
+// import { MemoizedLivelinessBar } from "@/components/map/Liveliness/LivelinessBar";
 // import { Bar } from "@/components/map/Liveliness/Bar";
-import { MemoizedRelativeLivelinessBar } from "@/components/map/Liveliness/RelativeLivelinessBar";
+// import { MemoizedRelativeLivelinessBar } from "@/components/map/Liveliness/RelativeLivelinessBar";
 import { MemoizedBookmarksSidebar } from "@/components/map/Sidebar/SidebarV2/BookmarksSidebar";
 import { MemoizedChatSidebar } from "@/components/map/Sidebar/SidebarV2/ChatSidebar";
 import { CitationsSidebar } from "@/components/map/Sidebar/SidebarV2/CitationsSidebar";
@@ -409,7 +409,7 @@ const Notebook = ({}: NotebookProps) => {
     isEnabled: false,
   });
 
-  const [openLivelinessBar, setOpenLivelinessBar] = useState(false);
+  const [openLivelinessBar] = useState(false);
   const [comLeaderboardOpen, setComLeaderboardOpen] = useState(false);
   const [assistantSelectNode, setAssistantSelectNode] = useState<boolean>(false);
 
@@ -8393,7 +8393,7 @@ const Notebook = ({}: NotebookProps) => {
 
           {/* end Data from map */}
 
-          {window.innerHeight > 399 && user?.livelinessBar === "relativeInteractions" && (
+          {/* {window.innerHeight > 399 && user?.livelinessBar === "relativeInteractions" && (
             <MemoizedRelativeLivelinessBar
               onToggleDisplay={() => setOpenLivelinessBar(prev => !prev)}
               onlineUsers={onlineUsers}
@@ -8435,7 +8435,7 @@ const Notebook = ({}: NotebookProps) => {
               variant="absoluteReputations"
               onToggleDisplay={() => setOpenLivelinessBar(prev => !prev)}
             />
-          )}
+          )} */}
 
           {focusView.isEnabled && (
             <MemoizedFocusedNotebook


### PR DESCRIPTION
## Description

- Hide the liveliness bar and fixed the issue of "Tag it" Button not showing

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
