### PR TITLE
fix the text of "Link to an existing Child node" button to "Link to an existing Child"

### DIFF
--- a/src/components/map/LinkingWords/LinkingWords.tsx
+++ b/src/components/map/LinkingWords/LinkingWords.tsx
@@ -644,11 +644,11 @@ const LinkingWords = ({
               {editable && !isNew && nodeType !== "Reference" && notebookRef.current.selectedNode === identifier && (
                 <MemoizedMetaButton
                   onClick={choosingNewLinkedNode("Child")}
-                  tooltip="Link to an existing child node."
+                  tooltip="Link to an existing Child."
                   tooltipPosition="right"
                 >
                   <>
-                    <span>Link to an existing Child node</span>
+                    <span>Link to an existing Child</span>
                     <AddIcon sx={{ color: "#00E676", fontSize: "16px" }} />
                     <ArrowForwardIcon sx={{ color: "#00E676", fontSize: "16px" }} />
                   </>


### PR DESCRIPTION
## Description

- fix the text of "Link to an existing Child node" button to "Link to an existing Child"

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
