### PR TITLE
Change the next button to "Edit [COURSE DESCRIPTION] OR Continue" The "Edit [COURSE DESCRIPTION] OR" part should be just text with large font size, and the button should be "Continue". We should change [COURSE DESCRIPTION] to whatever the field is about

### DIFF
--- a/src/pages/course-creation.tsx
+++ b/src/pages/course-creation.tsx
@@ -899,7 +899,11 @@ const CourseComponent = () => {
 
     return () => clearTimeout(timeoutId);
   };
-
+  const getStepTitle = () => {
+    if (creatingCourseStep === 0) {
+      return "Course Title";
+    }
+  };
   const nextStep = () => {
     if (creatingCourseStep === 2) {
       generatePrerequisiteKnowledge();
@@ -1002,7 +1006,26 @@ const CourseComponent = () => {
         onSwitchSection={() => {}}
         aiCourse={true}
       />
-
+      {courses[selectedCourse].new && creatingCourseStep <= 6 && (
+        <LoadingButton
+          variant="contained"
+          color="error"
+          sx={{
+            color: "white",
+            zIndex: 9,
+            fontSize: "15px",
+            mt: "15px",
+            position: "absolute",
+            right: 0,
+            mr: "4px",
+            height: "34px",
+          }}
+          onClick={cancelCreatingCourse}
+          loading={loading}
+        >
+          Close
+        </LoadingButton>
+      )}
       <Box padding="20px">
         <Box>
           {!courses[selectedCourse]?.new && (
@@ -1611,25 +1634,19 @@ const CourseComponent = () => {
                 gap: "5px",
               }}
             >
-              <LoadingButton
-                variant="contained"
-                color="success"
-                sx={{ color: "white", zIndex: 9, fontSize: "15px" }}
-                onClick={nextStep}
-                loading={loading}
-                disabled={nextButtonDisabled(courses[selectedCourse])}
-              >
-                Next
-              </LoadingButton>
-              <LoadingButton
-                variant="contained"
-                color="error"
-                sx={{ color: "white", zIndex: 9, fontSize: "15px", ml: "15px" }}
-                onClick={cancelCreatingCourse}
-                loading={loading}
-              >
-                Cancel
-              </LoadingButton>
+              <Box sx={{ display: "flex", alignItems: "center", gap: "5px", fontWeight: "bold" }}>
+                <Typography>Edit {getStepTitle()} OR </Typography>
+                <LoadingButton
+                  variant="contained"
+                  color="success"
+                  sx={{ color: "white", zIndex: 9, fontSize: "15px" }}
+                  onClick={nextStep}
+                  loading={loading}
+                  disabled={nextButtonDisabled(courses[selectedCourse])}
+                >
+                  Continue
+                </LoadingButton>
+              </Box>
             </Box>
           )}
           <Dialog


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Ref # (issue)

## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [ ] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?