### PR TITLE
remove question_type Matching from the example for retrieveGenerateQuestions

### DIFF
--- a/src/pages/api/retrieveGenerateQuestions.ts
+++ b/src/pages/api/retrieveGenerateQuestions.ts
@@ -133,33 +133,6 @@ OR
 }
 OR
 {
-  "question_type": "Matching",
-  "question_text": "Match each organelle with its function.",
-  "pairs": [
-    {
-      "term": "Mitochondria",
-      "definition": "Produces energy for the cell",
-      "feedback": "The mitochondria generate most of the cell's supply of ATP, used as a source of chemical energy."
-    },
-    {
-      "term": "Ribosome",
-      "definition": "Synthesizes proteins",
-      "feedback": "Ribosomes are responsible for protein synthesis in the cell."
-    },
-    {
-      "term": "Chloroplast",
-      "definition": "Conducts photosynthesis",
-      "feedback": "Chloroplasts capture light energy to produce sugars during photosynthesis."
-    },
-    {
-      "term": "Golgi apparatus",
-      "definition": "Modifies and packages proteins",
-      "feedback": "The Golgi apparatus processes and packages proteins and lipids for secretion or delivery to other organelles."
-    }
-  ]
-}
-OR
-{
   "question_type": "Fill in the Blank",
   "question_text": "The powerhouse of the cell is the ____. ",
   "correct_answer": "mitochondria",


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Ref # (issue)

## Checklist

- [ ] Was the latest code pulled and merged before requesting this PR?
- [ ] Did you check all unit tests passed?
- [ ] Did you check all e2e tests passed?
- [ ] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?