### PR TITLE
add tree view of parent and childrens, source material open on new tab and fix cached data of node public view

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,8 @@ module.exports = {
       "1cademy.us",
       "randomuser.me",
       "img.freepik.com",
+      "storage.cloud.google.com",
+      "www.core-econ.org",
     ],
     minimumCacheTTL: 315360,
   },

--- a/src/components/courseCreation/PublicView/prerequisiteNodes.tsx
+++ b/src/components/courseCreation/PublicView/prerequisiteNodes.tsx
@@ -1,0 +1,73 @@
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import { SxProps, Theme } from "@mui/system";
+import { TreeItem, TreeView } from "@mui/x-tree-view";
+import React from "react";
+
+import TypographyUnderlined from "../../TypographyUnderlined";
+
+type PrerequisiteNodeFieldProps = {
+  nodeType: string;
+  content: string;
+  nodeSlug: string;
+  node: string;
+  label?: string;
+  title: string;
+  nodes?: PrerequisiteNodeFieldProps[];
+};
+
+type PrerequisiteNodeProps = {
+  nodes: PrerequisiteNodeFieldProps[];
+  sx?: SxProps<Theme>;
+  header: string;
+};
+
+const PrerequisiteNodes = ({ nodes, sx, header }: PrerequisiteNodeProps) => {
+  const renderPrerequisiteNodes = (nodes: PrerequisiteNodeFieldProps[]) => {
+    return nodes.map((el, idx) => (
+      <React.Fragment key={idx}>
+        <TreeItem
+          sx={{ "& .MuiTreeItem-content": { py: 3 } }}
+          label={el.title}
+          nodeId={`${el.title}-${idx}`}
+          key={`${el.title}-${idx}`}
+        >
+          {el?.nodes && el?.nodes?.length > 0 && <>{renderPrerequisiteNodes(el.nodes)}</>}
+        </TreeItem>
+      </React.Fragment>
+    ));
+  };
+
+  return (
+    <Card sx={{ ...sx }}>
+      <CardHeader
+        sx={{
+          backgroundColor: theme =>
+            theme.palette.mode === "light" ? theme.palette.common.darkGrayBackground : theme.palette.common.black,
+          // color: theme => theme.palette.common.white,
+        }}
+        title={
+          <Box sx={{ textAlign: "center", color: "inherit" }}>
+            <TypographyUnderlined
+              variant="h6"
+              fontWeight="300"
+              gutterBottom
+              align="center"
+              sx={{ color: theme => theme.palette.common.white }}
+            >
+              {header}
+            </TypographyUnderlined>
+          </Box>
+        }
+      ></CardHeader>
+      <TreeView defaultCollapseIcon={<ExpandMoreIcon />} defaultExpandIcon={<ChevronRightIcon />}>
+        {renderPrerequisiteNodes(nodes)}
+      </TreeView>
+    </Card>
+  );
+};
+
+export default PrerequisiteNodes;

--- a/src/pages/course-creation.tsx
+++ b/src/pages/course-creation.tsx
@@ -61,6 +61,7 @@ import { QuestionProps } from "src/types";
 import { INode } from "src/types/INode";
 
 import ChipInput from "@/components/ChipInput";
+import PrerequisiteNodes from "@/components/courseCreation/PublicView/prerequisiteNodes";
 import CaseStudy from "@/components/courseCreation/questions/CaseStudy";
 import Essay from "@/components/courseCreation/questions/Essay";
 import FillInTheBlank from "@/components/courseCreation/questions/FillInTheBlank";
@@ -1699,25 +1700,25 @@ const CourseComponent = () => {
           retrieveNodeQuestions(nodeId);
         }
 
-        // if (!node?.updatedStr) {
-        setNodePublicViewLoader(true);
-        const nodeResponse = await getNodeDataForCourse(nodeId);
-        const updatedData = {
-          ...node,
-          createdStr,
-          updatedStr,
-          keywords,
-          children: nodeResponse.children,
-          parents: nodeResponse.parents,
-          contributors: nodeResponse.contributors,
-          institutions: nodeResponse.institutions,
-          references: nodeResponse.references,
-        };
-        course.nodes[topicTitle][idx] = updatedData;
-        setNodePublicView({ ...updatedData, topic: topicTitle });
-        updateCourses(course);
-        setNodePublicViewLoader(false);
-        // }
+        if (!("updatedStr" in (node ?? {}))) {
+          setNodePublicViewLoader(true);
+          const nodeResponse = await getNodeDataForCourse(nodeId);
+          const updatedData = {
+            ...node,
+            createdStr,
+            updatedStr,
+            keywords,
+            children: nodeResponse.children,
+            parents: nodeResponse.parents,
+            contributors: nodeResponse.contributors,
+            institutions: nodeResponse.institutions,
+            references: nodeResponse.references,
+          };
+          course.nodes[topicTitle][idx] = updatedData;
+          setNodePublicView({ ...updatedData, topic: topicTitle });
+          updateCourses(course);
+          setNodePublicViewLoader(false);
+        }
       }
     },
     [courses, selectedCourseIdx, updateCourses]
@@ -2953,7 +2954,12 @@ const CourseComponent = () => {
                   <Grid item xs={12} sm={12}>
                     {(nodePublicView?.references || [])?.length > 0 && (
                       // <ReferencesList references={nodePublicView.references || []} sx={{ mt: 3 }} />
-                      <LinkedNodes data={nodePublicView?.references || []} header="Source Material" showIcon={false} />
+                      <LinkedNodes
+                        data={nodePublicView?.references || []}
+                        header="Source Material"
+                        showIcon={false}
+                        openInNewTab={true}
+                      />
                     )}
                   </Grid>
                   <Grid item xs={12} sm={12}>
@@ -3108,15 +3114,10 @@ const CourseComponent = () => {
                           />
                         </Card>
                       </Grid>
-                      <Grid item xs={12} sm={12}>
+                      <Grid mt={2} item xs={12} sm={12}>
                         {nodePublicView?.parents && nodePublicView?.parents?.length > 0 && (
                           <>
-                            <LinkedNodes
-                              data={nodePublicView?.parents || []}
-                              header="What to Learn Before"
-                              showIcon={false}
-                              readonly={true}
-                            />
+                            <PrerequisiteNodes header="What to Learn Before" nodes={nodePublicView?.parents || []} />
                             <Box sx={{ display: "flex", justifyContent: "center", my: 2 }}>
                               <CustomButton
                                 variant="contained"
@@ -3141,12 +3142,7 @@ const CourseComponent = () => {
                       <Grid item xs={12} sm={12}>
                         {nodePublicView?.children && nodePublicView?.children?.length > 0 && (
                           <>
-                            <LinkedNodes
-                              data={nodePublicView?.children || []}
-                              header="What to Learn After"
-                              showIcon={false}
-                              readonly={true}
-                            />
+                            <PrerequisiteNodes header="What to Learn After" nodes={nodePublicView?.children || []} />
                             <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
                               <CustomButton
                                 variant="contained"


### PR DESCRIPTION
## Description

- add tree view of parent and childrens, source material open on new tab and fix cached data of node public view

## Checklist

- [x] Was the latest code pulled and merged before requesting this PR?
- [x] Did you check all unit tests passed?
- [x] Did you check all e2e tests passed?
- [x] Did you run `npm run build` to check the changes generate no new eslint warnings/errors?
